### PR TITLE
Added start delay

### DIFF
--- a/config/uberAgent-ESA-si-vastlimits-windows.conf
+++ b/config/uberAgent-ESA-si-vastlimits-windows.conf
@@ -9,22 +9,24 @@
 ############################################
 
 [Timer]
-Name       = Modular security inventory timer
-Interval   = 86400000
-Persist interval = true
-UA metric  = SecurityInventory.Antivirus
-UA metric  = SecurityInventory.Firewall
-UA metric  = SecurityInventory.LocalUsersAndGroups
-UA metric  = SecurityInventory.Network
-UA metric  = SecurityInventory.PowerShell
-UA metric  = SecurityInventory.Service
-UA metric  = SecurityInventory.WindowsConfiguration
+Name              = Modular security inventory timer
+Interval          = 86400000
+Start delay       = 600000
+Persist interval  = true
+UA metric         = SecurityInventory.Antivirus
+UA metric         = SecurityInventory.Firewall
+UA metric         = SecurityInventory.LocalUsersAndGroups
+UA metric         = SecurityInventory.Network
+UA metric         = SecurityInventory.PowerShell
+UA metric         = SecurityInventory.Service
+UA metric         = SecurityInventory.WindowsConfiguration
 
 [Timer]
-Name       = Modular security inventory timer for Certificate
-Interval   = 86400000
-Persist interval = true
-UA metric  = SecurityInventory.Certificate
+Name              = Modular security inventory timer for Certificate
+Interval          = 86400000
+Start delay       = 600000
+Persist interval  = true
+UA metric         = SecurityInventory.Certificate
 
 ############################################
 #


### PR DESCRIPTION
Without a start delay, customers would need to wait the full-timer interval (24h by default) to see MSI data in dashboards. That could lead to irritation whether uberAgent is running correctly.