### PR TITLE
Rename configuration option to match wording on Windows.

### DIFF
--- a/config/uberAgent-remote-config-macOS.conf
+++ b/config/uberAgent-remote-config-macOS.conf
@@ -5,7 +5,7 @@
 # uberAgent-remote-config-macOS.conf serves as the configuration file for central configuration management.
 
 #
-# Documentation: https://uberagent.com/docs/uberagent/latest/planning/configuration-options/
+# Documentation: https://uberagent.com/docs/uberagent/latest/installation/central-config-file-management/
 #
 
 ############################################
@@ -14,8 +14,8 @@
 #
 # Configurable settings in this section:
 #
-#   Setting name: RemoteConfigPath
-#   Description: The path to configuration files on a remote source. This should be a path to a mounted SMB share.
+#   Setting name: ConfigFilePath
+#   Description: The path to the configuration archive on a remote source. This should be a path to a mounted SMB share.
 #   Valid values: Any valid path to a subfolder under /Volumes, e.g. "/Volumes/share/configuration" (quotes may be used, but are not necessary)
 #   Default: empty
 #   Required: yes


### PR DESCRIPTION
To keep the wording across platforms consistent, the configuration option for specifying the path to the configuration archive under macOS was renamed to match the Windows client's terminology.