### PR TITLE
Fixed config problems

### DIFF
--- a/config-dev/Security inventory/Windows/Antivirus/Antivirus.ps1
+++ b/config-dev/Security inventory/Windows/Antivirus/Antivirus.ps1
@@ -4,42 +4,24 @@
 . $PSScriptRoot\..\Shared\Helper.ps1 -Force
 
 #https://mcpforlife.com/2020/04/14/how-to-resolve-this-state-value-of-av-providers/
-if (-not ("AV_ProductState" -as [type])) {
-   Add-Type -TypeDefinition @"
-   public enum AV_ProductState
-   {
-      Off = 0x0000,
-      On = 0x1000,
-      Snoozed = 0x2000,
-      Expired = 0x3000
-   }
-"@
-
-   Add-Type -TypeDefinition @"
-   public enum AV_SignatureStatus
-   {
-      UpToDate = 0x00,
-      OutOfDate = 0x10
-   }
-"@
-
-   Add-Type -TypeDefinition @"
-   public enum AV_ProductOwner
-   {
-      NonMs = 0x000,
-      Windows = 0x100
-   }
-"@
-
-   Add-Type -TypeDefinition @"
-   public enum AV_ProductFlags
-   {
-      SignatureStatus = 0x000000F0,
-      ProductOwner = 0x00000F00,
-      ProductState = 0x0000F000
-   }
-"@
+$AV_ProductState = @{
+   Off     = 0x0000
+   On      = 0x1000
+   Snoozed = 0x2000
+   Expired = 0x3000
 }
+
+$AV_SignatureStatus = @{
+   UpToDate  = 0x00
+   OutOfDate = 0x10
+}
+
+$AV_ProductFlags = @{
+   SignatureStatus = 0x000000F0
+   ProductOwner    = 0x00000F00
+   ProductState    = 0x0000F000
+}
+
 
 function Get-vlAntivirusStatus {
    <#
@@ -93,8 +75,8 @@ function Get-vlAntivirusStatus {
             $avEnabledFound = $false
 
             foreach ($instance in $instances) {
-               $avEnabled = $([AV_ProductState]::On.value__ -eq $($instance.productState -band [AV_ProductFlags]::ProductState) )
-               $avUp2Date = $([AV_SignatureStatus]::UpToDate.value__ -eq $($instance.productState -band [AV_ProductFlags]::SignatureStatus) )
+               $avEnabled = $($AV_ProductState["On"] -eq $($instance.productState -band $AV_ProductFlags["ProductState"]) )
+               $avUp2Date = $($AV_SignatureStatus["UpToDate"] -eq $($instance.productState -band $AV_ProductFlags["SignatureStatus"]) )
 
                if ($avEnabled) {
                   $avEnabledFound = $true

--- a/config-dev/Security inventory/Windows/Firewall/Firewall.ps1
+++ b/config-dev/Security inventory/Windows/Firewall/Firewall.ps1
@@ -2,7 +2,7 @@
 #Requires -Version 3.0
 . $PSScriptRoot\..\Shared\Helper.ps1 -Force
 
-$FW_IP_PROTOCOL_TCP = @{
+$FW_PROTOCOL = @{
    ICMPv4 = 1
    TCP    = 6
    UDP    = 17
@@ -213,7 +213,7 @@ function Get-vlOpenFirewallPorts {
                }
 
                if ($null -ne $rule.Profiles) {
-                  $parsedProtocol = Get-vlHashTableKey -hashTable $FW_IP_PROTOCOL_TCP -value $rule.Protocol
+                  $parsedProtocol = Get-vlHashTableKey -hashTable $FW_PROTOCOL -value $rule.Protocol
                }
 
                $output += [PSCustomObject]@{

--- a/config-dev/Security inventory/Windows/LocalUserAndGroups/LocalUsersAndGroups-Machine.ps1
+++ b/config-dev/Security inventory/Windows/LocalUserAndGroups/LocalUsersAndGroups-Machine.ps1
@@ -1,34 +1,29 @@
 #Requires -Version 3.0
 . $PSScriptRoot\..\Shared\Helper.ps1 -Force
 
-if (-not ("WinBioStatus" -as [type])) {
-   Add-Type -TypeDefinition @"
-   public enum WinBioStatus : uint
-   {
-      MULTIPLE = 0x00000001,
-      FACIAL_FEATURES = 0x00000002,
-      VOICE = 0x00000004,
-      FINGERPRINT = 0x00000008,
-      IRIS = 0x00000010,
-      RETINA = 0x00000020,
-      HAND_GEOMETRY = 0x00000040,
-      SIGNATURE_DYNAMICS = 0x00000080,
-      KEYSTROKE_DYNAMICS = 0x00000100,
-      LIP_MOVEMENT = 0x00000200,
-      THERMAL_FACE_IMAGE = 0x00000400,
-      THERMAL_HAND_IMAGE = 0x00000800,
-      GAIT = 0x00001000,
-      SCENT = 0x00002000,
-      DNA = 0x00004000,
-      EAR_SHAPE = 0x00008000,
-      FINGER_GEOMETRY = 0x00010000,
-      PALM_PRINT = 0x00020000,
-      VEIN_PATTERN = 0x00040000,
-      FOOT_PRINT = 0x00080000,
-      OTHER = 0x40000000,
-      PASSWORD = 0x80000000
-   }
-"@
+$WinBioStatus = @{
+   MULTIPLE           = 0x00000001
+   FACIAL_FEATURES    = 0x00000002
+   VOICE              = 0x00000004
+   FINGERPRINT        = 0x00000008
+   IRIS               = 0x00000010
+   RETINA             = 0x00000020
+   HAND_GEOMETRY      = 0x00000040
+   SIGNATURE_DYNAMICS = 0x00000080
+   KEYSTROKE_DYNAMICS = 0x00000100
+   LIP_MOVEMENT       = 0x00000200
+   THERMAL_FACE_IMAGE = 0x00000400
+   THERMAL_HAND_IMAGE = 0x00000800
+   GAIT               = 0x00001000
+   SCENT              = 0x00002000
+   DNA                = 0x00004000
+   EAR_SHAPE          = 0x00008000
+   FINGER_GEOMETRY    = 0x00010000
+   PALM_PRINT         = 0x00020000
+   VEIN_PATTERN       = 0x00040000
+   FOOT_PRINT         = 0x00080000
+   OTHER              = 0x40000000
+   PASSWORD           = 0x80000000
 }
 
 function Get-vlUACState {
@@ -272,11 +267,10 @@ function Get-vlMachineAvailableFactors () {
 
    $availableFactors = Get-vlRegValue -Hive "HKLM" -Path $winBioSensorInfoBasePath -Value "AvailableFactors"
 
-   # iterate over [WinBioStatus].GetEnumNames() and check if the bit is set. If bit is set, save matching enum names in array $availableFac
    $availableFac = @()
-   foreach ($factor in [WinBioStatus].GetEnumNames()) {
-      if ($availableFactors -band [WinBioStatus]::$factor) {
-         $availableFac += $factor
+   foreach ($factor in $WinBioStatus.GetEnumerator()) {
+      if ($availableFactors -band $factor.value) {
+         $availableFac += $factor.key
       }
    }
 
@@ -285,7 +279,6 @@ function Get-vlMachineAvailableFactors () {
       WinBioUsed             = $winBioUsed
       WinBioAvailableFactors = $availableFac
    }
-
 }
 
 function Get-vlWindowsHelloStatusLocalMachine () {

--- a/config-dev/Security inventory/Windows/LocalUserAndGroups/LocalUsersAndGroups-User.ps1
+++ b/config-dev/Security inventory/Windows/LocalUserAndGroups/LocalUsersAndGroups-User.ps1
@@ -1,35 +1,29 @@
 #Requires -Version 3.0
 . $PSScriptRoot\..\Shared\Helper.ps1 -Force
 
-
-if (-not ("WinBioStatus" -as [type])) {
-   Add-Type -TypeDefinition @"
-   public enum WinBioStatus : uint
-   {
-      MULTIPLE = 0x00000001,
-      FACIAL_FEATURES = 0x00000002,
-      VOICE = 0x00000004,
-      FINGERPRINT = 0x00000008,
-      IRIS = 0x00000010,
-      RETINA = 0x00000020,
-      HAND_GEOMETRY = 0x00000040,
-      SIGNATURE_DYNAMICS = 0x00000080,
-      KEYSTROKE_DYNAMICS = 0x00000100,
-      LIP_MOVEMENT = 0x00000200,
-      THERMAL_FACE_IMAGE = 0x00000400,
-      THERMAL_HAND_IMAGE = 0x00000800,
-      GAIT = 0x00001000,
-      SCENT = 0x00002000,
-      DNA = 0x00004000,
-      EAR_SHAPE = 0x00008000,
-      FINGER_GEOMETRY = 0x00010000,
-      PALM_PRINT = 0x00020000,
-      VEIN_PATTERN = 0x00040000,
-      FOOT_PRINT = 0x00080000,
-      OTHER = 0x40000000,
-      PASSWORD = 0x80000000
-   }
-"@
+$WinBioStatus = @{
+   MULTIPLE           = 0x00000001
+   FACIAL_FEATURES    = 0x00000002
+   VOICE              = 0x00000004
+   FINGERPRINT        = 0x00000008
+   IRIS               = 0x00000010
+   RETINA             = 0x00000020
+   HAND_GEOMETRY      = 0x00000040
+   SIGNATURE_DYNAMICS = 0x00000080
+   KEYSTROKE_DYNAMICS = 0x00000100
+   LIP_MOVEMENT       = 0x00000200
+   THERMAL_FACE_IMAGE = 0x00000400
+   THERMAL_HAND_IMAGE = 0x00000800
+   GAIT               = 0x00001000
+   SCENT              = 0x00002000
+   DNA                = 0x00004000
+   EAR_SHAPE          = 0x00008000
+   FINGER_GEOMETRY    = 0x00010000
+   PALM_PRINT         = 0x00020000
+   VEIN_PATTERN       = 0x00040000
+   FOOT_PRINT         = 0x00080000
+   OTHER              = 0x40000000
+   PASSWORD           = 0x80000000
 }
 
 function Get-vlIsLocalAdmin {
@@ -119,11 +113,10 @@ function Get-vlGetUserEnrolledFactors() {
 
    $enroledFactors = Get-vlRegValue -Hive "HKLM" -Path ("SOFTWARE\Microsoft\Windows\CurrentVersion\WinBio\AccountInfo\" + $currentUserSID) -Value "EnrolledFactors"
 
-   # iterate over [WinBioStatus].GetEnumNames() and check if the bit is set. If bit is set, save matching enum names in array $enroleFactors
    $enroledFac = @()
-   foreach ($factor in [WinBioStatus].GetEnumNames()) {
-      if ($enroledFactors -band [WinBioStatus]::$factor) {
-         $enroledFac += $factor
+   foreach ($factor in $WinBioStatus.GetEnumerator()) {
+      if ($enroledFactors -band $factor.value) {
+         $enroledFac += $factor.key
       }
    }
 

--- a/config-dev/Security inventory/Windows/Shared/Helper.ps1
+++ b/config-dev/Security inventory/Windows/Shared/Helper.ps1
@@ -376,6 +376,55 @@ function Get-vlRegSubkeys {
    }
 }
 
+function Get-vlHashTableKey {
+   <#
+    .SYNOPSIS
+        Retrieves the key from a hashtable corresponding to a specified value.
+    .DESCRIPTION
+        This function takes as input a hashtable and a value. It searches the hashtable for entries where the value matches the provided value.
+        It returns the key(s) of matching entries.
+    .PARAMETERS
+        - hashTable: The hashtable to search.
+        - value: The value to search for in the hashtable.
+    .OUTPUTS
+        Returns the key(s) from the hashtable where the value matches the input value. If no match is found, returns $null. If multiple matches are found, returns all matching keys.
+    .EXAMPLE
+        $parsedProfile = Get-vlHashTableKey -hashTable $FW_PROFILES -value $rule.Profiles
+    #>
+
+   param(
+      [Hashtable]$hashTable,
+      [Object]$value
+   )
+
+   $hashTable.GetEnumerator() | Where-Object { $_.Value -eq $value } | ForEach-Object { $_.Name }
+}
+
+
+function Get-vlHashTableKeys {
+   <#
+    .SYNOPSIS
+        Returns the key names from a hashtable that correspond to the bits set in a given flag value.
+    .DESCRIPTION
+        This function takes a hashtable and a flag value as input. It uses bitwise operations to check which bits are set in the flag value.
+        For each set bit, it finds the corresponding key in the hashtable and returns these keys.
+    .PARAMETERS
+        - hashTable: A hashtable where each value is a power of 2, corresponding to a bit position in a flag.
+        - value: The flag value to check. This should be an integer where each set bit corresponds to a key in the hashtable.
+    .OUTPUTS
+        Returns a list of key names from the hashtable that correspond to the bits set in the flag value.
+    .EXAMPLE
+        $parsedProfile = Get-vlHashTableKeys -hashTable $FW_PROFILES -value $rule.Profiles
+    #>
+
+   param(
+      [Hashtable]$hashTable,
+      [Object]$value
+   )
+
+   $hashTable.GetEnumerator() | Where-Object { ($value -band $_.Value) -ne 0 } | ForEach-Object { $_.Name }
+}
+
 
 function Get-vlTimeScore($time) {
    <#


### PR DESCRIPTION
Enums under PowerShell 3.0 and 4.0 can only be declared via .Net. However, this would require further security customizations, which is why I have now changed the ENUM's to hashtabs and built corresponding helpers. This leads to the fact that we do not need .NET code.