### PR TITLE
Remove ./sigma/rules/web/proxy_generic/proxy_webdav_search_ms.yml

### DIFF
--- a/convert-sigma-rules.sh
+++ b/convert-sigma-rules.sh
@@ -37,6 +37,7 @@ git clone https://github.com/SigmaHQ/sigma.git
 # remove files causing crashes
 rm ./sigma/rules/windows/builtin/security/account_management/win_security_successful_external_remote_rdp_login.yml
 rm ./sigma/rules/windows/builtin/security/account_management/win_security_successful_external_remote_smb_login.yml
+rm ./sigma/rules/web/proxy_generic/proxy_webdav_search_ms.yml
 
 # navigate to sigma directory for further git commands
 cd legacy-sigmatools


### PR DESCRIPTION
This rule breaks the current converter. Exclude it as long as we have not yet updated the sigma toolchain. 

- Verified in my fork: https://github.com/svnscha/uberAgent-config/actions/runs/5948020243/job/16131033807