### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -13,15 +13,19 @@ jobs:
           - branch: version/6.2
             pipeline_version: "uberagent-6.2.0"
             copy_rules_args: "--skip_platform"
+            pypi-host: "https://test.pypi.org/simple"
           - branch: version/7.0
             pipeline_version: "uberagent-7.0.0"
             copy_rules_args: "--skip_platform"
+            pypi-host: "https://test.pypi.org/simple"
           - branch: version/7.1
             pipeline_version: "uberagent-7.1.0"
             copy_rules_args: ""
+            pypi-host: "https://test.pypi.org/simple"
           - branch: develop
             pipeline_version: "uberagent-develop"
             copy_rules_args: ""
+            pypi-host: "https://test.pypi.org/simple"
 
     runs-on: ubuntu-latest
 
@@ -81,7 +85,11 @@ jobs:
 
     - name: Install pySigma-backend-uberAgent from pyPI
       working-directory: ./sigma-cli
-      run: poetry add pySigma-backend-uberAgent
+      env:
+        PYPI_HOST: ${{ matrix.pypi-host }}
+      run: |
+        poetry source add ua_package_source ${{ matrix.pypi-host }}
+        poetry add --source ua_package_source pySigma-backend-uberAgent
 
     - name: Prepare Build
       run: mkdir build

--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -43,34 +43,35 @@ jobs:
 
     steps:
     - name: Checkout uberAgent-config
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         path: uberAgent-config
 
     - name: Checkout uberAgent-config [${{ matrix.branch }}]
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         ref: ${{ matrix.branch }}
         path: uberAgent-config-target
 
     - name: Checkout pySigma-backend-uberAgent
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         repository: vastlimits/pySigma-backend-uberAgent
         path: pySigma-backend-uberAgent
+        ref: "develop"
 
     - name: Checkout sigma-cli
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         repository: SigmaHQ/sigma-cli
         path: sigma-cli
 
     - name: Checkout sigma
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         repository: SigmaHQ/sigma

--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -12,27 +12,31 @@ jobs:
         include:
           - branch: version/6.2
             pipeline_version: "uberagent-6.2.0"
-            backend_version: ""
+            backend-version: ""
             copy_rules_args: "--skip_platform"
             pypi-host: "https://test.pypi.org/simple"
+            converter-ref: "main"
 
           - branch: version/7.0
             pipeline_version: "uberagent-7.0.0"
+            backend-version: ""
             copy_rules_args: "--skip_platform"
             pypi-host: "https://test.pypi.org/simple"
-            backend_version: ""
+            converter-ref: "main"
 
           - branch: version/7.1
             pipeline_version: "uberagent-7.1.0"
+            backend-version: ""
             copy_rules_args: ""
             pypi-host: "https://test.pypi.org/simple"
-            backend_version: ""
+            converter-ref: "main"
 
           - branch: develop
             pipeline_version: "uberagent-develop"
+            backend-version: "develop"
             copy_rules_args: ""
             pypi-host: "https://test.pypi.org/simple"
-            backend_version: "develop"
+            converter-ref: "develop"
 
     runs-on: ubuntu-latest
 
@@ -55,13 +59,13 @@ jobs:
         ref: ${{ matrix.branch }}
         path: uberAgent-config-target
 
-    - name: Checkout pySigma-backend-uberAgent
+    - name: Checkout pySigma-backend-uberAgent [${{ matrix.converter-ref }}]
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.VLSVC_PAT }}
         repository: vastlimits/pySigma-backend-uberAgent
         path: pySigma-backend-uberAgent
-        ref: "develop"
+        ref: ${{ matrix.converter-ref }}
 
     - name: Checkout sigma-cli
       uses: actions/checkout@v4
@@ -106,7 +110,7 @@ jobs:
       working-directory: build
       env:
         CURRENT_PIPELINE_VERSION: ${{ matrix.pipeline_version }}
-        CURRENT_BACKEND_VERSION: ${{ matrix.backend_version }}
+        CURRENT_backend-version: ${{ matrix.backend-version }}
         COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
       run: |
         # Activate poetry shell from sigma-cli in this shell
@@ -118,7 +122,7 @@ jobs:
 
         # Convert rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh
-        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_BACKEND_VERSION
+        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_backend-version
 
     - name: Push
       working-directory: uberAgent-config-target

--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -12,20 +12,27 @@ jobs:
         include:
           - branch: version/6.2
             pipeline_version: "uberagent-6.2.0"
+            backend_version: ""
             copy_rules_args: "--skip_platform"
             pypi-host: "https://test.pypi.org/simple"
+
           - branch: version/7.0
             pipeline_version: "uberagent-7.0.0"
             copy_rules_args: "--skip_platform"
             pypi-host: "https://test.pypi.org/simple"
+            backend_version: ""
+
           - branch: version/7.1
             pipeline_version: "uberagent-7.1.0"
             copy_rules_args: ""
             pypi-host: "https://test.pypi.org/simple"
+            backend_version: ""
+
           - branch: develop
             pipeline_version: "uberagent-develop"
             copy_rules_args: ""
             pypi-host: "https://test.pypi.org/simple"
+            backend_version: "develop"
 
     runs-on: ubuntu-latest
 
@@ -98,6 +105,7 @@ jobs:
       working-directory: build
       env:
         CURRENT_PIPELINE_VERSION: ${{ matrix.pipeline_version }}
+        CURRENT_BACKEND_VERSION: ${{ matrix.backend_version }}
         COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
       run: |
         # Activate poetry shell from sigma-cli in this shell
@@ -109,7 +117,7 @@ jobs:
 
         # Convert rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh
-        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION
+        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_BACKEND_VERSION
 
     - name: Push
       working-directory: uberAgent-config-target

--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -14,28 +14,28 @@ jobs:
             pipeline_version: "uberagent-6.2.0"
             backend-version: ""
             copy_rules_args: "--skip_platform"
-            pypi-host: "https://test.pypi.org/simple"
+            pypi-host: "https://pypi.org/simple"
             converter-ref: "main"
 
           - branch: version/7.0
             pipeline_version: "uberagent-7.0.0"
             backend-version: ""
             copy_rules_args: "--skip_platform"
-            pypi-host: "https://test.pypi.org/simple"
+            pypi-host: "https://pypi.org/simple"
             converter-ref: "main"
 
           - branch: version/7.1
             pipeline_version: "uberagent-7.1.0"
             backend-version: ""
             copy_rules_args: ""
-            pypi-host: "https://test.pypi.org/simple"
+            pypi-host: "https://pypi.org/simple"
             converter-ref: "main"
 
           - branch: develop
             pipeline_version: "uberagent-develop"
             backend-version: "develop"
             copy_rules_args: ""
-            pypi-host: "https://test.pypi.org/simple"
+            pypi-host: "https://pypi.org/simple"
             converter-ref: "develop"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -110,7 +110,7 @@ jobs:
       working-directory: build
       env:
         CURRENT_PIPELINE_VERSION: ${{ matrix.pipeline_version }}
-        CURRENT_backend-version: ${{ matrix.backend-version }}
+        CURRENT_BACKEND_VERSION: ${{ matrix.backend-version }}
         COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
       run: |
         # Activate poetry shell from sigma-cli in this shell
@@ -122,7 +122,7 @@ jobs:
 
         # Convert rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh
-        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_backend-version
+        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_BACKEND_VERSION
 
     - name: Push
       working-directory: uberAgent-config-target


### PR DESCRIPTION
This PR enhances the CI pipeline to 

- make it possible to specify a `pypi-host` so that forked repositories can easily switch to `test.pypi.org`.
- make it possible to specify a converter-ref per branch using the appropriate Sigma converter for that specific branch. That way develop changes can actually be tested without touching release branches.

Tested in this run:

- https://github.com/svnscha/uberAgent-config/actions/runs/7052187348

and it just changed `develop` as seen here:

- https://github.com/svnscha/uberAgent-config/commit/2def47a2fa0ad650ebd90825a7a43f2606476b7c

Note: After merging this PR the current pySigma-backend-uberAgent version must be released to production pypi which is currently at test.pypi.