### PR TITLE
B842: Implement additional directories to add more rules.

### DIFF
--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -120,6 +120,27 @@ jobs:
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules" $COPY_RULES_ARGS
 
+    - name: Build (develop extra)
+      if: ${{ matrix.branch == 'develop' }}
+      working-directory: build
+      run: |
+        # Activate poetry shell from sigma-cli in this shell
+        . $(cd $GITHUB_WORKSPACE/sigma-cli ; poetry env info --path)/bin/activate
+
+        # For testing, limited to develop.
+        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules-threat-hunting" --skip_check_directory
+        $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules-emerging-threats" --skip_check_directory
+
+    - name: Convert
+      working-directory: build
+      env:
+        CURRENT_PIPELINE_VERSION: ${{ matrix.pipeline_version }}
+        CURRENT_BACKEND_VERSION: ${{ matrix.backend-version }}
+        COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
+      run: |
+        # Activate poetry shell from sigma-cli in this shell
+        . $(cd $GITHUB_WORKSPACE/sigma-cli ; poetry env info --path)/bin/activate
+
         # Convert rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_BACKEND_VERSION


### PR DESCRIPTION
I have updated our pipelines to include some rules-emerging-threats and rules-threat-hunting. The other 2 directories are empty.

**rules-emerging-threats**
```
[I] Selected 24 rules [sigma-critical-common]
[I] Selected 46 rules [sigma-high-common]
[I] Selected 63 rules [sigma-critical-windows]
[I] Selected 13 rules [sigma-medium-windows]
[I] Selected 129 rules [sigma-high-windows]
[I] Selected 10 rules [sigma-medium-common]
[I] Selected 3 rules [sigma-low-windows]
```
**rules-threat-hunting**
```
[I] Selected 13 rules [sigma-low-windows]
[I] Selected 25 rules [sigma-medium-windows]
```

As we can see it selects a couple of new rules which is great. The new rules coming after merging this can be pre-tested from here: 

- https://github.com/vastlimits/uberAgent-config/commit/47ed715cbd776bc735ed5f73a21af63be7b15621