### PR TITLE
Added git clone depth 1

### DIFF
--- a/Tools/InvokeuberAgentConfigDownload/InvokeuberAgentConfigDownload.ps1
+++ b/Tools/InvokeuberAgentConfigDownload/InvokeuberAgentConfigDownload.ps1
@@ -107,8 +107,8 @@ function Invoke-GitClone {
     $tempDir = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
 
-    # Clone the specific branch to the temp directory
-    git clone -b $Branch $RepoUrl $tempDir
+    # Clone the latest snapshot from the chosen branch to the temp directory
+    git clone -b $Branch $RepoUrl $tempDir --depth 1
 
 
     # Process the includes


### PR DESCRIPTION
The `git clone` command could brake on mediocre networks. Added `--depth 1` to the command, as we don't need the complete git history, but only the files of the latest snapshot.