### PR TITLE
macOS: add option EnableCdHash

### DIFF
--- a/config/uberAgent.conf
+++ b/config/uberAgent.conf
@@ -713,6 +713,13 @@ AcroRd32.exe = 15000
 #   Default: true
 #   Required: no
 #
+#   Setting name: EnableCdHash
+#   Description: Enables the collection of an application's code directory hash. macOS only.
+#   Requires: ESA
+#   Valid values: true | false
+#   Default: true
+#   Required: no
+#
 #   Setting name: HashImageTypes
 #   Description: Defines on which objects to calculate hash values.
 #   Requires: ESA


### PR DESCRIPTION
This PR adds the macOS-specific option "EnableCdHash" to the stanza "ProcessStartupSettings". It enables/disables the collection of an application's/processes code directory hash.