### PR TITLE
Exclude the configuration-check workflow from working branches

### DIFF
--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -136,6 +136,7 @@ jobs:
 
 
   publish-archive:
+    if: ${{ github.event_name == "push" }}
     needs: [validate-archive]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -12,6 +12,8 @@ on:
     branches:
     - develop
     - "version/7.1"
+    paths-ignore:
+    - "config-dist/**"    # avoid recursion
     
 env:
   SOURCE_DIR_PATH:  config/

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -2,10 +2,10 @@ name: Create config archive
 
 on:
   push:
-    branches-ignore:
-    - "main"
-    - "version/7.0"
-    - "version/6.2"
+    branches:
+    - develop
+    - "version/7.1"       # don't use a glob-pattern here! Config-archives 
+                          # are only supported starting uberAgent 7.1
     paths-ignore:
     - "config-dist/**"    # avoid recursion
   pull_request:

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -8,8 +8,7 @@ on:
                           # are only supported starting uberAgent 7.1
     paths-ignore:
     - "config-dist/**"    # avoid recursion
-  pull_request_target:
-    types: [opened, synchronize, reopened, auto_merge_enabled]
+  pull_request:
     branches:
     - develop
     - "version/7.1"

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -136,7 +136,7 @@ jobs:
 
 
   publish-archive:
-    if: ${{ github.event_name == "push" }}
+    if: ${{ github.event_name == 'push' }}
     needs: [validate-archive]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -8,7 +8,8 @@ on:
                           # are only supported starting uberAgent 7.1
     paths-ignore:
     - "config-dist/**"    # avoid recursion
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, auto_merge_enabled]
     branches:
     - develop
     - "version/7.1"

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -39,10 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.ref_name }}
-        token: ${{ secrets.VLSVC_PAT }}
+      uses: actions/checkout@v4
         
     - name: Create archive file
       uses: thedoctor0/zip-release@0.7.1

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -8,6 +8,9 @@ on:
     - "version/6.2"
     paths-ignore:
     - "config-dist/**"    # avoid recursion
+  pull_request:
+    branches:
+    - develop
     
 env:
   SOURCE_DIR_PATH:  config/

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -66,7 +66,6 @@ jobs:
         mv "$SOURCE_DIR_PATH$TARGET_FILE" "$TARGET_DIR_PATH"
 
     - name: 'Login via azure/login@v1'
-      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/login@v1
       with:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -75,7 +74,6 @@ jobs:
         environment: azurecloud
 
     - name: download uAConfigCheck exe
-      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/CLI@v1
       with:
         azcliversion: 2.55.0
@@ -90,7 +88,6 @@ jobs:
                                           --file-filter 'uAConfigCheck.exe'
           
     - name: download uAConfigCheck dll
-      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/CLI@v1
       with:
         azcliversion: 2.55.0
@@ -105,7 +102,6 @@ jobs:
                                           --file-filter "uberAgent-${{env.uAConfigCheck_DLL_Artifact_ProductVersion}}.dll"
     
     - uses: actions/upload-artifact@v4
-      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       with:
         name: uAConfigCheck
         path: |
@@ -115,7 +111,6 @@ jobs:
 
 
   validate-archive:
-    if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
     needs: [create-archive]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.ref_name }}
         token: ${{ secrets.VLSVC_PAT }}

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.ref_name }}
         token: ${{ secrets.VLSVC_PAT }}

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
     - develop
+    - "version/7.1"
     
 env:
   SOURCE_DIR_PATH:  config/

--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -62,6 +62,7 @@ jobs:
         mv "$SOURCE_DIR_PATH$TARGET_FILE" "$TARGET_DIR_PATH"
 
     - name: 'Login via azure/login@v1'
+      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/login@v1
       with:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -70,6 +71,7 @@ jobs:
         environment: azurecloud
 
     - name: download uAConfigCheck exe
+      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/CLI@v1
       with:
         azcliversion: 2.55.0
@@ -84,6 +86,7 @@ jobs:
                                           --file-filter 'uAConfigCheck.exe'
           
     - name: download uAConfigCheck dll
+      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       uses: azure/CLI@v1
       with:
         azcliversion: 2.55.0
@@ -98,6 +101,7 @@ jobs:
                                           --file-filter "uberAgent-${{env.uAConfigCheck_DLL_Artifact_ProductVersion}}.dll"
     
     - uses: actions/upload-artifact@v4
+      if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
       with:
         name: uAConfigCheck
         path: |
@@ -107,6 +111,7 @@ jobs:
 
 
   validate-archive:
+    if: ${{ github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/version/') }}
     needs: [create-archive]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ValidateConfig.yml
+++ b/.github/workflows/ValidateConfig.yml
@@ -1,15 +1,11 @@
 name: Validate configuration
 on:
-  push:
-    branches-ignore:
-    - "main"
-    - "version/7.0"
-    - "version/6.2"
-    paths-ignore:
-    - "config-dist/**"    # avoid recursion
   pull_request:
     branches:
     - develop
+    - "main"
+    - "version/7.0"
+    - "version/6.2"
 
 
 env:

--- a/.github/workflows/ValidateConfig.yml
+++ b/.github/workflows/ValidateConfig.yml
@@ -4,8 +4,7 @@ on:
     branches:
     - develop
     - "main"
-    - "version/7.0"
-    - "version/6.2"
+    - "version/*"
 
 
 env:


### PR DESCRIPTION
- Prevent the ValidateConfig-workflow from running on development branches.
- Restrict the CreateArchive workflow only to the develop- and version/7.1 branches.
This is due to the need to manually juggle OIDC for development branches.