### PR TITLE
macOS: add B802 and B803 to default configuration

### DIFF
--- a/config/uberAgent-ESA-si-vastlimits-macos.conf
+++ b/config/uberAgent-ESA-si-vastlimits-macos.conf
@@ -16,6 +16,8 @@ UA metric         = SecurityInventory.Firewall
 UA metric         = SecurityInventory.RemoteLogin
 UA metric         = SecurityInventory.Updates
 UA metric         = SecurityInventory.OsConfiguration
+UA metric         = SecurityInventory.NetworkConfiguration
+UA metric         = SecurityInventory.Antivirus
 
 ############################################
 #
@@ -61,5 +63,23 @@ Category = OsConfiguration
 ScriptId = 11d9441b-a2fd-40ee-9912-e5057fd50f8e
 ScriptTimeoutMs = 600000
 ScriptCommandline = "###UA_SI_LOCALPATH###/OsConfiguration/OsConfiguration.zsh"
+Interpreter = zsh
+ScriptContext = Root
+
+[SecurityInventoryTest]
+Name = NetworkConfiguration
+Category = NetworkConfiguration
+ScriptId = 31cbcd42-8430-4832-bc0f-6667d8870440
+ScriptTimeoutMs = 600000
+ScriptCommandline = "###UA_SI_LOCALPATH###/NetworkConfiguration/NetworkConfiguration.zsh"
+Interpreter = zsh
+ScriptContext = Root
+
+[SecurityInventoryTest]
+Name = Antivirus
+Category = Antivirus
+ScriptId = dcd13614-68fc-4398-a5f7-d5532883ea2b
+ScriptTimeoutMs = 600000
+ScriptCommandline = "###UA_SI_LOCALPATH###/Antivirus/Antivirus.zsh"
 Interpreter = zsh
 ScriptContext = Root


### PR DESCRIPTION
This PR adds the network configuration and antivirus SCI tests to the default configuration for being run automatically.