### PR TITLE
Summarize the SCI SSH test results in a single test result.

### DIFF
--- a/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
+++ b/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
@@ -273,7 +273,7 @@ vlFilterRiskyAlgos()
 
 vlScoreAlgorithmList()
 {
-  local testName="$1"
+  local prefix="$1"
   local goodAlgosList="$2"
   local knownRiskyAlgos="$3"
   local algosListToCheck="$4"
@@ -282,14 +282,14 @@ vlScoreAlgorithmList()
   local nonCompliantAlgosList
   nonCompliantAlgosList=$( vlFilterNonCompliantAlgos "$goodAlgosList" "${algosListToCheck}" )
   if (( $? != 0 )); then
-    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${testName}.NonCompliantAlgorithms" "$nonCompliantAlgosList")
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-NonCompliantAlgorithms" "$nonCompliantAlgosList")
 
     local riskyAlgosList
     riskyAlgosList=$( vlFilterRiskyAlgos "$knownRiskyAlgos" "$nonCompliantAlgosList" )
     if (( $? == 0 )); then
       score=5
     else
-      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${testName}.CriticalRiskAlgorithms" "$riskyAlgosList")
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-CriticalRiskAlgorithms" "$riskyAlgosList")
       score=0
     fi
   fi
@@ -310,7 +310,7 @@ vlCheckKeysStrongEncryption()
   local goodAlgosList="curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
 
   vlScoreAlgorithmList \
-    "$testName" \
+    "SshKexAlgorithms" \
     "$goodAlgosList" \
     "$knownRiskyAlgos" \
     "${sshdConfiguration[KexAlgorithms]}"
@@ -329,7 +329,7 @@ vlCheckCiphersStrongEncryption()
   local goodAlgosList="chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
 
   vlScoreAlgorithmList \
-    "$testName" \
+    "SshCiphers" \
     "$goodAlgosList" \
     "$knownRiskyAlgos" \
     "${sshdConfiguration[Ciphers]}"
@@ -348,7 +348,7 @@ vlCheckMacsStrongEncryption()
   local goodAlgosList="hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
 
   vlScoreAlgorithmList \
-    "$testName" \
+    "SshMacAlgorithms" \
     "$goodAlgosList" \
     "$knownRiskyAlgos" \
     "${sshdConfiguration[MACs]}"

--- a/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
+++ b/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
@@ -2,53 +2,13 @@
 # Security and Compliance Inventory: Remote Login
 #
 
-vlCheckRemoteLoginDisabled()
-{
-  local testName="SSHLoginDisabled"
-  local testDisplayName="macOS remote login"
-  local testDescription="Turning off remote login over SSH eliminates an access point that could potentially be exploited, increasing system security. Checks whether remote login over ssh is disabled."
-  local riskScore=40
+# Global variables collecting the results for each executed test
+scoresForAllTests=()
+resultDataForAllTests="{}"
 
-  local expectedOutput="Remote Login: Off"
-  local expectedGrepStatus=0
-  local expectedTestResultDataValue=true
-  local testResultVarName='Disabled'
+# Maps sshd configuration options to their respective effective values; see vlLoadSshdConfig()
+typeset -A sshdConfiguration
 
-    vlCheckFeatureStateFromCommandOutput \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$riskScore" \
-    "$expectedOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    systemsetup -getremotelogin
-}
-
-vlCheckRootUserDisabled()
-{
-  local testName="SSHRootUserDisabled"
-  local testDisplayName="macOS root user"
-  local testDescription="Enabling the root user can pose a security risk as it provides full access and control over the system. Checks whether the macOS root user is disabled."
-  local riskScore=60
-
-  local dontMatchOutput="ShadowHashData"
-  local expectedGrepStatus=1
-  local expectedTestResultDataValue=true
-  local testResultVarName='Disabled'
-
-  vlCheckFeatureStateFromCommandOutput \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$riskScore" \
-    "$dontMatchOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    plutil -p /var/db/dslocal/nodes/Default/users/root.plist
-}
 
 # Sort the comma-separated ssh option values so that they can be matched using
 # regular string comparison.
@@ -59,50 +19,156 @@ vlGetComparableOptionString()
   printf "$options" | tr -d '[:blank:]' | tr "," "\n" | sort | tr "\n" "," | sed 's/,$/\n/'
 }
 
-vlEnsureValidSshdConfig()
+
+# Loads the configuration options passed in as arguments to the global sshdConfiguration map.
+vlLoadSshdConfig()
 {
   local testName="$1"
   local testDisplayName="$2"
   local testDescription="$3"
 
-  if (( $SSHCONFIGSTATUS == 0 )) && [ -n "$SSHEFFECTIVECONFIG" ]; then
-    return 0
-  fi
+  shift 3
 
-  vlReportErrorJson \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    128 \
-    "Unable to get the sshd effective configuration."
+  vlRunCommand sshd -T
+  local sshConfigStatus="$vlCommandStatus"
+  local effectiveSshdConfig="$vlCommandStdout"
 
-  return 1
-}
-
-# This function relies on the global variable ${SSHEFFECTIVECONFIG} being set.
-vlGetSshdConfigOpt()
-{
-  local configOpt="$1"                # The configuration option to look for
-  local testName="$2"                 # The name of the test being performed
-  local testDisplayName="$3"          # The display name of the test
-  local testDescription="$4"          # A description of the test
-
-  # Use grep -i for case-insensitive search and awk to extract the value
-  local configOptValue=$(printf "${SSHEFFECTIVECONFIG}\n" | grep -i "$configOpt" | awk '{ print $2 }')
-
-  # Check if configOptValue is empty
-  if [ -z "$configOptValue" ]; then
+  if (( $sshConfigStatus != 0 )) || [ -z "$effectiveSshdConfig" ]; then
     vlReportErrorJson \
       "$testName" \
       "$testDisplayName" \
       "$testDescription" \
-      1 \
-      "Unable to find the sshd $configOpt configuration option."
-    return
+      128 \
+      "Unable to get the Remote Login configuration (sshd status code: ${sshConfigStatus})"
+
+    return 1
   fi
 
-  # Safely call vlGetComparableOptionString with quotes to handle spaces or special characters
-  printf "%s" "$(vlGetComparableOptionString "$configOptValue")"
+  for sshdConfigOptName in $@; do
+    local sshdConfigOptValue=$(printf "${effectiveSshdConfig}\n" | grep -i "$sshdConfigOptName" | awk '{ print $2 }')
+    if [ -z "$sshdConfigOptValue" ]; then
+      vlReportErrorJson \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        1 \
+        "The $sshdConfigOptName option was not found in the effective sshd configuration."
+
+      return 1
+    fi
+
+    sshdConfiguration[$sshdConfigOptName]="$( vlGetComparableOptionString "$sshdConfigOptValue" )"
+  done
+
+  return 0
+}
+
+
+# If the configuration cannot be loaded even though Remote Login is on
+# --which is very unlikely-- an error for the whole test is returned.
+# Returns: 0 when sshd is enabled, 1 when disabled and 2 on error.
+vlCheckRemoteLoginEnabled()
+{
+  local testName="SSHLoginDisabled"
+  local displayName="macOS remote login"
+  local description="Turning off remote login over SSH eliminates an access point that could potentially be exploited, increasing system security. Checks whether remote login over ssh is disabled."
+  local expectedOutput="Remote Login: On"
+
+  vlRunCommand systemsetup -getremotelogin
+  printf "$vlCommandStdout" | grep -i "Error" >/dev/null 2>&1
+  if (( $? == 0 )); then
+      vlReportErrorJson \
+        "$testName" \
+        "$displayName" \
+        "$description" \
+        1 \
+        "$vlCommandStdout"
+      return 2
+  fi
+
+  local resultDataPropertyName="RemoteLoginEnabled"
+  printf "$vlCommandStdout" | grep -i "$expectedOutput" >/dev/null 2>&1
+  case $? in
+    0)
+      # Remote Login is enabled
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+      ;;
+    1)
+      # Remote Login is disabled
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+
+      # TODO: review this!
+      local testScore=10
+      local riskScore=40
+
+      vlCreateResultObject \
+        "$testName" \
+        "$displayName" \
+        "$description" \
+        "$testScore" \
+        "$riskScore" \
+        "$resultDataForAllTests"
+
+      return 1
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$displayName" \
+        "$description" \
+        "$grepStatus" \
+        "Internal test error: pattern matching failed."
+      return 2
+      ;;
+  esac
+
+  return 0
+}
+
+
+# Score:
+#   10  Root login is disabled.
+#    7  Allow only specific commands to be executed by the root user.
+#    4  Allow root login but only with key-based methods.
+#    0  Allow root login with any authentification method.
+#
+#   On error, the appropriate JSON is output to stdout and a non-zero value is returned.
+vlCheckRootLoginDisabled()
+{
+  # TODO: Review name, display name and description!
+  local testName="SSHRootLoginDisabled"
+  local testDisplayName="macOS root login"
+  local testDescription="TODO"
+
+  local rootLogin="${sshdConfiguration[PermitRootLogin]}"
+  case "$rootLogin" in
+    no)
+      scoresForAllTests+=(10)
+      ;;
+    forced-commands-only)
+      scoresForAllTests+=(7)
+      ;;
+    prohibit-password|without-password)
+      scoresForAllTests+=(4)
+      ;;
+    yes)
+      scoresForAllTests+=(0)
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$displayName" \
+        "$description" \
+        1 \
+        "Invalid value for PermitRootLogin: $rootLogin"
+
+      return 1
+      ;;
+  esac
+
+  resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "AllowRootLogin" "${rootLogin}")
+
+  return 0
 }
 
 
@@ -113,32 +179,19 @@ vlCheckSshPasswordLoginDisabled()
   local testDescription="Disabling password login over SSH reduces the risk of brute force attacks by requiring more secure cryptographic keys for access. Checks whether remote password logins are disabled on macOS."
   local riskScore=50
 
-  vlEnsureValidSshdConfig "$testName" "$testDisplayName" "$testDescription" || return
-
-  local passwordConfigOpt=$(
-    vlGetSshdConfigOpt "passwordauthentication" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$passwordConfigOpt" ] || return
-
-  local testScore=10
+  local score=10
   local isDisabled=true
-  if [ "$passwordConfigOpt" = "yes" ]; then
-    testScore=$( vlGetMinScore "$riskScore" )
+  if [ "${sshdConfiguration[PasswordAuthentication]}" = "yes" ]; then
+    score=$( vlGetMinScore "$riskScore" )
     isDisabled=false
   fi
 
-  local resultData=$(vlAddResultValue "{}" "Disabled" $isDisabled)
+  scoresForAllTests+=(${score})
+  resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "PasswordAuthDisabled" $isDisabled)
 
-  vlCreateResultObject \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$testScore" \
-    "$riskScore" \
-    "$resultData"
+  return 0
 }
+
 
 vlCheckSshFipsCompliant()
 {
@@ -147,139 +200,98 @@ vlCheckSshFipsCompliant()
   local testDescription="Making remote logins FIPS (Federal Information Processing Standards) compliant, enhances security by enforcing stringent encryption standards. Checks whether the remote login configuration is FIPS compliant."
   local riskScore=60
 
-  vlEnsureValidSshdConfig "$testName" "$testDisplayName" "$testDescription" || return
-
-  local ciphers=$(
-    vlGetSshdConfigOpt "Ciphers" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$ciphers" ] || return
-
-  local hostAcceptedAlgos=$(
-    vlGetSshdConfigOpt "HostbasedAcceptedAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$hostAcceptedAlgos" ] || return
-
-  local hostKeyAlgos=$(
-    vlGetSshdConfigOpt "HostKeyAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$hostKeyAlgos" ] || return
-
-  local kexAlgos=$(
-    vlGetSshdConfigOpt "KexAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$kexAlgos" ] || return
-
-  local macs=$(
-    vlGetSshdConfigOpt "MACs" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$macs" ] || return
-
-  local pubkeyAcceptedAlgos=$(
-    vlGetSshdConfigOpt "PubkeyAcceptedAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$pubkeyAcceptedAlgos" ] || return
-
-  local caAlgos=$(
-    vlGetSshdConfigOpt "CASignatureAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$caAlgos" ] || return
-
   # see appleSshAndFips(7)
+  local rc=1
   local isFipsCompliant=false
-  local testScore=$( vlGetMinScore "$riskScore" )
-  if [ "$ciphers" = "aes128-gcm@openssh.com" \
-    -a "$hostAcceptedAlgos" = "$( vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com )" \
-    -a "$hostKeyAlgos" = "$( vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com )" \
-    -a "$kexAlgos" = "ecdh-sha2-nistp256" \
-    -a "$macs" = "hmac-sha2-256" \
-    -a "$pubkeyAcceptedAlgos" = "$( vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com )" \
-    -a "$caAlgos" = "ecdsa-sha2-nistp256" ]
+  if [ "${sshdConfiguration[Ciphers]}" = "aes128-gcm@openssh.com" \
+    -a "${sshdConfiguration[HostbasedAcceptedAlgorithms]}" = "$(vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com)" \
+    -a "${sshdConfiguration[HostKeyAlgorithms]}" = "$(vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com)" \
+    -a "${sshdConfiguration[KexAlgorithms]}" = "ecdh-sha2-nistp256" \
+    -a "${sshdConfiguration[MACs]}" = "hmac-sha2-256" \
+    -a "${sshdConfiguration[PubkeyAcceptedAlgorithms]}" = "$(vlGetComparableOptionString ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com)" \
+    -a "${sshdConfiguration[CASignatureAlgorithms]}" = "ecdsa-sha2-nistp256" ]
   then
     isFipsCompliant=true
-    testScore=10
+    scoresForAllTests+=(10)
+    rc=0
   fi
 
-  local resultData=$(vlAddResultValue "{}" "IsFipsCompliant" $isFipsCompliant)
+  resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "FipsCompliant" $isFipsCompliant)
 
-  vlCreateResultObject \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$testScore" \
-    "$riskScore" \
-    "$resultData"
+  return $rc
 }
 
-# Returns the comma-separated values in inputString that match a value in expectedString.
-vlGetMatchingAndNonMatchingValues()
+
+vlFilterNonCompliantAlgos()
 {
-  local inputString=$1
-  local expectedString=$2
+  local expectedArray=("${(@s:,:)1}")
+  local actualArray=("${(@s:,:)2}")
 
-  shift 2
+  typeset -A expectedMap
+  for value in "${expectedArray[@]}"; do
+    expectedMap[$value]=1
+  done
 
-  local -a inputValues=(${(s:,:)inputString})
-  local -a expectedValues=(${(s:,:)expectedString})
-  local matchedValues=""
-  local unmatchedValues=""
-
-  local missingValue=0
-
-  for expectedValue in "${expectedValues[@]}"; do
-    local valueExists=0
-    for inputValue in "${inputValues[@]}"; do
-      if [[ $inputValue == $expectedValue ]]; then
-        matchedValues+="\"${inputValue}\","
-        valueExists=1
-        break
-      fi
-    done
-
-    if (( valueExists == 0 )); then
-      unmatchedValues+="\"${expectedValue}\","
-      missingValue=1
+  local badValues=()
+  for value in "${actualArray[@]}"; do
+    if [[ -z ${expectedMap[$value]} ]]; then
+      badValues+=($value)
     fi
   done
 
-  MATCHED_VALUES=$(printf "%s" "$matchedValues" | sed 's/,$//')
-  UNMATCHED_VALUES=$(printf "%s" "$unmatchedValues" | sed 's/,$//')
+  printf "${(j:,:)badValues}\n"
+  return ${#badValues[@]}
 }
 
-vlGetTestScoreOnMatchingValues()
+
+vlFilterRiskyAlgos()
 {
-  local matches=$1
-  local unmatched=$2
-  local riskScore=$3
+  local riskyAlgosArray=("${(@s:,:)1}")
+  local actualAlgosArray=("${(@s:,:)2}")
 
-  shift 3
+  typeset -A riskyAlgosMap
+  for value in "${riskyAlgosArray[@]}"; do
+    riskyAlgosMap[$value]=1
+  done
 
-  local -a matchingValues=(${(s:,:)matches})
-  local -a unmatchingValues=(${(s:,:)unmatched})
+  local riskyAlgos=()
+  for value in "${actualAlgosArray[@]}"; do
+    if [[ -n ${riskyAlgosMap[$value]} ]]; then
+      riskyAlgos+=($value)
+    fi
+  done
 
-  local expectedValuesCount=$(( ${#matchingValues[@]} + ${#unmatchingValues[@]} ))
-
-  local minScore=$( vlGetMinScore $riskScore )
-
-  local testScore=$(echo "scale=2; ($minScore + ((10 - $minScore) * ${#matchingValues[@]} / $expectedValuesCount))" | bc -l)
-  ## This unusual construction is required for bc to round the score as one would expect.
-  local roundedTestScore=$(echo "scale=2; ($testScore + 0.5)/1" | bc -l)
-
-  printf "%d" $roundedTestScore
+  printf "${(j:,:)riskyAlgos}\n"
+  return ${#riskyAlgos[@]}
 }
+
+
+vlScoreAlgorithmList()
+{
+  local testName="$1"
+  local goodAlgosList="$2"
+  local knownRiskyAlgos="$3"
+  local algosListToCheck="$4"
+
+  local score=10
+  local nonCompliantAlgosList
+  nonCompliantAlgosList=$( vlFilterNonCompliantAlgos "$goodAlgosList" "${algosListToCheck}" )
+  if (( $? != 0 )); then
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${testName}.NonCompliantAlgorithms" "$nonCompliantAlgosList")
+
+    local riskyAlgosList
+    riskyAlgosList=$( vlFilterRiskyAlgos "$knownRiskyAlgos" "$nonCompliantAlgosList" )
+    if (( $? == 0 )); then
+      score=5
+    else
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${testName}.CriticalRiskAlgorithms" "$riskyAlgosList")
+      score=0
+    fi
+  fi
+
+  scoresForAllTests+=(${score})
+}
+
 
 vlCheckKeysStrongEncryption()
 {
@@ -288,40 +300,17 @@ vlCheckKeysStrongEncryption()
   local testDescription="Checks whether the symmetric key algorithms that are used for remote login are considered strong."
   local riskScore=100
 
-  vlEnsureValidSshdConfig "$testName" "$testDisplayName" "$testDescription" || return
-
-  local kexAlgos=$( \
-    vlGetSshdConfigOpt "KexAlgorithms" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$kexAlgos" ] || return
-
+  local knownRiskyAlgos="diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1"
   ## see https://infosec.mozilla.org/guidelines/openssh
-  local expectedAlgos="curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+  local goodAlgosList="curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
 
-  vlGetMatchingAndNonMatchingValues \
-    "$kexAlgos" \
-    "$expectedAlgos"
-
-  local testScore=$( \
-    vlGetTestScoreOnMatchingValues \
-      "$MATCHED_VALUES" \
-      "$UNMATCHED_VALUES" \
-      "$riskScore" \
-    )
-
-  resultData=$(vlAddResultValue "{}" "matched" "[$MATCHED_VALUES]")
-  resultData=$(vlAddResultValue $resultData "unmatched" "[$UNMATCHED_VALUES]")
-
-  vlCreateResultObject \
+  vlScoreAlgorithmList \
     "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$testScore" \
-    "$riskScore" \
-    "$resultData"
+    "$goodAlgosList" \
+    "$knownRiskyAlgos" \
+    "${sshdConfiguration[KexAlgorithms]}"
 }
+
 
 vlCheckCiphersStrongEncryption()
 {
@@ -330,40 +319,17 @@ vlCheckCiphersStrongEncryption()
   local testDescription="Checks whether the cipher algorithms that are used for remote login are considered strong."
   local riskScore=100
 
-  vlEnsureValidSshdConfig "$testName" "$testDisplayName" "$testDescription" || return
-
-  local ciphers=$( \
-    vlGetSshdConfigOpt "Ciphers" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$ciphers" ] || return
-
+  local knownRiskyAlgos="3des-cbc"
   ## see https://infosec.mozilla.org/guidelines/openssh
-  local expectedCiphers="curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+  local goodAlgosList="chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
 
-  vlGetMatchingAndNonMatchingValues \
-      "$ciphers" \
-      "$expectedCiphers"
-
-    local testScore=$( \
-    vlGetTestScoreOnMatchingValues \
-      "$MATCHED_VALUES" \
-      "$UNMATCHED_VALUES" \
-      "$riskScore" \
-    )
-
-  resultData=$(vlAddResultValue "{}" "matched" "[$MATCHED_VALUES]")
-  resultData=$(vlAddResultValue $resultData "unmatched" "[$UNMATCHED_VALUES]")
-
-  vlCreateResultObject \
+  vlScoreAlgorithmList \
     "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$testScore" \
-    "$riskScore" \
-    "$resultData"
+    "$goodAlgosList" \
+    "$knownRiskyAlgos" \
+    "${sshdConfiguration[Ciphers]}"
 }
+
 
 vlCheckMacsStrongEncryption()
 {
@@ -372,33 +338,32 @@ vlCheckMacsStrongEncryption()
   local testDescription="Checks whether the MAC (Message Authentication Codes) algorithms that are used for remote login are considered strong."
   local riskScore=100
 
-  vlEnsureValidSshdConfig "$testName" "$testDisplayName" "$testDescription" || return
-
-  local macs=$( \
-    vlGetSshdConfigOpt "MACs" \
-      "$testName" \
-      "$testDisplayName" \
-      "$testDescription" )
-  [ -n "$macs" ] || return
-
-  local testScore=$( vlGetMinScore "$riskScore" )
-
+  local knownRiskyAlgos="hmac-md5,hmac-md5-96,hmac-sha1,hmac-sha1-96,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha1-96-etm@openssh.com"
   ## see https://infosec.mozilla.org/guidelines/openssh
-  local expectedMacs="hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
+  local goodAlgosList="hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
 
-  vlGetMatchingAndNonMatchingValues \
-      "$macs" \
-      "$expectedMacs"
+  vlScoreAlgorithmList \
+    "$testName" \
+    "$goodAlgosList" \
+    "$knownRiskyAlgos" \
+    "${sshdConfiguration[MACs]}"
+}
 
-  local testScore=$( \
-  vlGetTestScoreOnMatchingValues \
-    "$MATCHED_VALUES" \
-    "$UNMATCHED_VALUES" \
-    "$riskScore" \
-  )
 
-  resultData=$(vlAddResultValue "{}" "matched" "[$MATCHED_VALUES]")
-  resultData=$(vlAddResultValue $resultData "unmatched" "[$UNMATCHED_VALUES]")
+vlReportSshTestResults()
+{
+  local testName="$1"
+  local testDisplayName="$2"
+  local testDescription="$3"
+  local riskScore="$4"
+
+  # Use the average of all sub scores as the final score.
+  local sum=0
+  for score in "${scoresForAllTests[@]}"; do
+    sum=$((sum + score))
+  done
+
+  local testScore=$(echo "$sum / ${#scoresForAllTests[@]}" | bc)
 
   vlCreateResultObject \
     "$testName" \
@@ -406,7 +371,62 @@ vlCheckMacsStrongEncryption()
     "$testDescription" \
     "$testScore" \
     "$riskScore" \
-    "$resultData"
+    "$resultDataForAllTests"
+}
+
+
+vlSshDaemonTests()
+{
+  # TODO: Review: define testName, testDisplayName, testDescription
+  local testName="SSHDaemonTests"
+  local testDisplayName="TODO"
+  local testDescription="TODO"
+  local riskScore=10
+
+  vlCheckRemoteLoginEnabled || return $(( $? - 1 ))
+
+  vlLoadSshdConfig \
+    "$testName" \
+    "$testDisplayName" \
+    "$testDescription" \
+    PasswordAuthentication \
+    PermitRootLogin \
+    Ciphers \
+    HostbasedAcceptedAlgorithms \
+    HostKeyAlgorithms \
+    KexAlgorithms \
+    MACs \
+    PubkeyAcceptedAlgorithms \
+    CASignatureAlgorithms \
+    || return 1
+
+  vlCheckRootLoginDisabled || return 1
+  vlCheckSshPasswordLoginDisabled || return 1
+
+  vlCheckSshFipsCompliant
+  if (( $? == 0 )); then
+    # sshd is configured to be compliant with fips, which is secure and needs no further checking
+    scoresForAllTests+=(10)
+    vlReportSshTestResults \
+      "$testName" \
+      "$testDisplayName" \
+      "$testDescription" \
+      "$riskScore"
+
+    return 0
+  fi
+
+  vlCheckKeysStrongEncryption
+  vlCheckCiphersStrongEncryption
+  vlCheckMacsStrongEncryption
+
+  vlReportSshTestResults \
+    "$testName" \
+    "$testDisplayName" \
+    "$testDescription" \
+    "$riskScore"
+
+  return 0
 }
 
 ################################################################################
@@ -417,23 +437,8 @@ vlCheckMacsStrongEncryption()
 vlUtils="$(cd "$(dirname "$0")/.." && pwd)/Utils.zsh"
 . "$vlUtils" && vlInit
 
+# Require root rights to start
 [ "$(id -u)" = "0" ] || { printf "Error: This script must be run as root.\n" >&2; exit 64; }
 
 # Run the tests
-results=()
-
-results+="$( vlCheckRemoteLoginDisabled )"
-results+="$( vlCheckRootUserDisabled )"
-
-# The sshd configuration is required for the next tests
-vlRunCommand sshd -T
-SSHCONFIGSTATUS="$vlCommandStatus"
-SSHEFFECTIVECONFIG="$vlCommandStdout"
-
-results+="$( vlCheckSshPasswordLoginDisabled )"
-results+="$( vlCheckSshFipsCompliant )"
-results+="$( vlCheckKeysStrongEncryption )"
-results+="$( vlCheckCiphersStrongEncryption )"
-results+="$( vlCheckMacsStrongEncryption )"
-
-vlPrintJsonReport "${results[@]}"
+vlSshDaemonTests

--- a/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
+++ b/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
@@ -447,4 +447,8 @@ vlUtils="$(cd "$(dirname "$0")/.." && pwd)/Utils.zsh"
 [ "$(id -u)" = "0" ] || { printf "Error: This script must be run as root.\n" >&2; exit 64; }
 
 # Run the tests
-vlSshDaemonTests
+results=()
+
+results+="$( vlSshDaemonTests )"
+
+vlPrintJsonReport "${results[@]}"

--- a/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
+++ b/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
@@ -282,14 +282,14 @@ vlScoreAlgorithmList()
   local nonCompliantAlgosList
   nonCompliantAlgosList=$( vlFilterNonCompliantAlgos "$goodAlgosList" "${algosListToCheck}" )
   if (( $? != 0 )); then
-    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-NonCompliantAlgorithms" "$nonCompliantAlgosList")
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-NonCompliant" "$nonCompliantAlgosList")
 
     local riskyAlgosList
     riskyAlgosList=$( vlFilterRiskyAlgos "$knownRiskyAlgos" "$nonCompliantAlgosList" )
     if (( $? == 0 )); then
       score=5
     else
-      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-CriticalRiskAlgorithms" "$riskyAlgosList")
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${prefix}-CriticalRisk" "$riskyAlgosList")
       score=0
     fi
   fi

--- a/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
+++ b/config-dev/Security inventory/macOS/RemoteLogin/RemoteLogin.zsh
@@ -141,10 +141,9 @@ vlCheckRemoteLoginEnabled()
 #   On error, the appropriate JSON is output to stdout and a non-zero value is returned.
 vlCheckRootLoginDisabled()
 {
-  # TODO: Review name, display name and description!
   local testName="SSHRootLoginDisabled"
   local testDisplayName="macOS root login"
-  local testDescription="TODO"
+  local testDescription="This test validates whether root login via SSH is permitted. It is crucial to securing a system, as the root user has full privileges and can potentially cause system-wide changes."
 
   local rootLogin="${sshdConfiguration[PermitRootLogin]}"
   case "$rootLogin" in
@@ -383,10 +382,9 @@ vlReportSshTestResults()
 
 vlSshDaemonTests()
 {
-  # TODO: Review: define testName, testDisplayName, testDescription
   local testName="SSHDaemonTests"
-  local testDisplayName="TODO"
-  local testDescription="TODO"
+  local testDisplayName="SSH daemon settings"
+  local testDescription="This suite of tests performs multiple checks on the SSH daemon configuration, including remote login, password login, encryption techniques, etc., to assess the currently active settings' security level."
   local riskScore=10
 
   vlCheckRemoteLoginEnabled || return $(( $? - 1 ))


### PR DESCRIPTION
As we talked about recently, the behavior of the macOS SCI tests should be modified to make it more consistent with the behavior on the Windows side. This PR addresses that requirement and [Martin's feedback on the SSH tests](https://podio.com/tasks/278021680).

The control flow of the updated SSH tests can be read in the `vlSshDaemonTests()` function. The most important aspect is that the tests break if SSH is disabled and no further tests are run. Another caveat is that when SSH is enabled, if the configuration is FIPS compliant, then that is understood to be a secure configuration, therefore skipping the more detailed following tests.

Either a single test score or an error is reported.

See the [test protocol](https://podio.com/uberagentcom/uberagent-dev/apps/test-protocols/items/571) for detailed information on the expectations.

@martin-kretzschmar  Please adapt and modify the TODO sections that have to do with wording!

From a coding perspective, the biggest change is that all SSH configuration is read into a map in the `vlLoadSshdConfig()`. This makes it possible to fail fast if there were any missing configuration options. It also removes a lot of crufty error-handling code from each test, enhancing overall readability.