### PR TITLE
Aggregate all firewall tests to a single test score.

### DIFF
--- a/config-dev/Security inventory/Windows/Firewall/Firewall.ps1
+++ b/config-dev/Security inventory/Windows/Firewall/Firewall.ps1
@@ -368,7 +368,7 @@ function Get-vlFirewallCheck {
       $Output += [PSCustomObject]@{
          Name         = "FWState"
          DisplayName  = "Firewall status"
-         Description  = "Windows: This test verifies whether the Windows Defender Firewall is enabled or disabled. It also provides the current connection status of the network profiles. Network profiles allow the system to apply different firewall settings based on the network location, such as a public Wi-Fi network (Public), a corporate network (Domain), or a home network (Private).\nmacOS: Checks whether the macOS firewall is enabled."
+         Description  = "Windows: This test verifies whether the Windows Defender Firewall is enabled or disabled. It also provides the current connection status of the network profiles. Network profiles allow the system to apply different firewall settings based on the network location, such as a public Wi-Fi network (Public), a corporate network (Domain), or a home network (Private). macOS: performs comprehensive checking of firewall settings. If the firewall is enabled, this test also validates the status of the block-all rule, stealth mode, and a list of approved applications."
          Score        = $firewallEnabled.Score
          ResultData   = $firewallEnabled.Result
          RiskScore    = $firewallEnabled.RiskScore

--- a/config-dev/Security inventory/macOS/Firewall/Firewall.zsh
+++ b/config-dev/Security inventory/macOS/Firewall/Firewall.zsh
@@ -2,6 +2,11 @@
 # Security and Compliance Inventory: Firewall Tests
 #
 
+# Global variables collecting the results for each executed test
+scoresForAllTests=()
+resultDataForAllTests="{}"
+
+
 vlCheckIsFirewallEnabled()
 {
   local testName="FWState"
@@ -9,21 +14,50 @@ vlCheckIsFirewallEnabled()
   local testDescription="Windows: This test verifies whether the Windows Defender Firewall is enabled or disabled. It also provides the current connection status of the network profiles. Network profiles allow the system to apply different firewall settings based on the network location, such as a public Wi-Fi network (Public), a corporate network (Domain), or a home network (Private).\nmacOS: Checks whether the macOS firewall is enabled."
   local riskScore=100
 
-  local expectedOutput="enabled"
-  local expectedGrepStatus=0
-  local expectedTestResultDataValue=true
-  local testResultVarName='Enabled'
+  vlRunCommand /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+  if (( $vlCommandStatus != 0 )); then
+    vlReportErrorJson \
+      "$testName" \
+      "$testDisplayName" \
+      "$testDescription" \
+      "$vlCommandStatus" \
+      "$vlCommandStderr"
+    return 2
+  fi
 
-  vlCheckFeatureStateFromCommandOutput \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$riskScore" \
-    "$expectedOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+  local resultDataPropertyName="FirewallEnabled"
+  printf "$vlCommandStdout" | grep "enabled" >/dev/null 2>&1
+  case $? in
+    0)
+      # The firewall is enabled
+      scoresForAllTests+=(10)
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+      return 0
+      ;;
+    1)
+      # The firewall is disabled
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+
+      vlCreateResultObject \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        0 \
+        "$riskScore" \
+        "$resultDataForAllTests"
+
+      return 1
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        "$?" \
+        "Internal error: pattern matching failed."
+      return 2
+      ;;
+  esac
 }
 
 vlCheckIsFirewallBlockallRuleEnabled()
@@ -34,21 +68,42 @@ vlCheckIsFirewallBlockallRuleEnabled()
   local riskScore=70
   local expectedOutput="Firewall is set to block all non-essential incoming connections"
 
-  local expectedOutput="enabled"
-  local expectedGrepStatus=0
-  local expectedTestResultDataValue=true
-  local testResultVarName='Enabled'
+  vlRunCommand /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
+  if (( $vlCommandStatus != 0 )); then
+    vlReportErrorJson \
+      "$testName" \
+      "$testDisplayName" \
+      "$testDescription" \
+      "$vlCommandStatus" \
+      "$vlCommandStderr"
+    return 2
+  fi
 
-  vlCheckFeatureStateFromCommandOutput \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$riskScore" \
-    "$expectedOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    /usr/libexec/ApplicationFirewall/socketfilterfw --getblockall
+  local resultDataPropertyName="BlockAllRuleEnabled"
+  printf "$vlCommandStdout" | grep "Block all DISABLED" >/dev/null 2>&1
+  case $? in
+    0)
+      # Disabled
+      scoresForAllTests+=($( vlGetMinScore "$riskScore" ))
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+      ;;
+    1)
+      # Enabled
+      scoresForAllTests+=(10)
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        "$?" \
+        "Internal error: pattern matching failed."
+      return 2
+      ;;
+  esac
+
+  return 0
 }
 
 vlCheckIsFirewallStealthModeEnabled()
@@ -58,31 +113,50 @@ vlCheckIsFirewallStealthModeEnabled()
   local testDescription="Stealth mode is a feature that prevents the system from responding to network test requests. Checks whether the stealth mode of the macOS firewall is active."
   local riskScore=80
 
-  local expectedOutput="enabled"
-  local expectedGrepStatus=0
-  local expectedTestResultDataValue=true
-  local testResultVarName='Enabled'
+  vlRunCommand /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
+  if (( $vlCommandStatus != 0 )); then
+    vlReportErrorJson \
+      "$testName" \
+      "$testDisplayName" \
+      "$testDescription" \
+      "$vlCommandStatus" \
+      "$vlCommandStderr"
+    return 2
+  fi
 
-  vlCheckFeatureStateFromCommandOutput \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    "$riskScore" \
-    "$expectedOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    /usr/libexec/ApplicationFirewall/socketfilterfw --getstealthmode
+  local resultDataPropertyName="StealthModeEnabled"
+  printf "$vlCommandStdout" | grep "enabled" >/dev/null 2>&1
+  case $? in
+    0)
+      # Enabled
+      scoresForAllTests+=(10)
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+      ;;
+    1)
+      # Disabled
+      scoresForAllTests+=($( vlGetMinScore "$riskScore" ))
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        "$?" \
+        "Internal error: pattern matching failed."
+      return 2
+      ;;
+  esac
+
+  return 0
 }
 
+# This test is only informational so it doesn't have a score.
 vlGetFirewallApprovedApps()
 {
   local testName="FWApprovedApps"
   local testDisplayName="macOS approved applications"
   local testDescription="Provides a list of applications that may accept incoming connections. This test is only informational and always returns a fixed test score."
-  # This test is only informational and always returns a fixed test score
-  local testScore=10
-  local riskScore=0
 
   vlRunCommand /usr/libexec/ApplicationFirewall/socketfilterfw --listapps
   if (( $vlCommandStatus != 0 )); then
@@ -95,7 +169,7 @@ vlGetFirewallApprovedApps()
     return
   fi
 
-  local resultData=$(vlAddResultValue "{}" "ApprovedApplications" '[]')
+  resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "ApprovedApplications" '[]')
 
   printf "$vlCommandStdout" | \
     grep -B1 '( Allow incoming connections )' | \
@@ -104,10 +178,39 @@ vlGetFirewallApprovedApps()
     awk '{$1=$1};1' | \
   while IFS= read -r appPath
   do
-    resultData=$(vlAddResultValue "$resultData" "ApprovedApplications" "[\"$appPath\"]")
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "ApprovedApplications" "[\"$appPath\"]")
+  done
+}
+
+vlFirewallTests()
+{
+  vlCheckIsFirewallEnabled || return $(( $? - 1 ))
+
+  ## TODO: Review and adapt the user-facing text
+  local testName="Firewallo"
+  local testDisplayName="Firewall status"
+  local testDescription="Comprehensive firewall tests"
+  local riskScore=100
+
+  vlCheckIsFirewallBlockallRuleEnabled || return 1
+  vlCheckIsFirewallStealthModeEnabled || return 1
+  vlGetFirewallApprovedApps || return 1
+
+  # Use the average of all sub scores as the final score.
+  local sum=0
+  for score in "${scoresForAllTests[@]}"; do
+    sum=$((sum + score))
   done
 
-  vlCreateResultObject "$testName" "$testDisplayName" "$testDescription" "$testScore" "$riskScore" "$resultData"
+  local testScore=$(echo "$sum / ${#scoresForAllTests[@]}" | bc)
+
+  vlCreateResultObject \
+    "$testName" \
+    "$testDisplayName" \
+    "$testDescription" \
+    "$testScore" \
+    "$riskScore" \
+    "$resultDataForAllTests"
 }
 
 ################################################################################
@@ -120,10 +223,5 @@ vlUtils="$(cd "$(dirname "$0")/.." && pwd)/Utils.zsh"
 
 # Run the tests
 results=()
-
-results+="$( vlCheckIsFirewallEnabled )"
-results+="$( vlCheckIsFirewallBlockallRuleEnabled )"
-results+="$( vlCheckIsFirewallStealthModeEnabled )"
-results+="$( vlGetFirewallApprovedApps )"
-
+results+="$( vlFirewallTests )"
 vlPrintJsonReport "${results[@]}"

--- a/config-dev/Security inventory/macOS/Firewall/Firewall.zsh
+++ b/config-dev/Security inventory/macOS/Firewall/Firewall.zsh
@@ -9,9 +9,9 @@ resultDataForAllTests="{}"
 
 vlCheckIsFirewallEnabled()
 {
-  local testName="FWState"
-  local testDisplayName="Firewall status"
-  local testDescription="Windows: This test verifies whether the Windows Defender Firewall is enabled or disabled. It also provides the current connection status of the network profiles. Network profiles allow the system to apply different firewall settings based on the network location, such as a public Wi-Fi network (Public), a corporate network (Domain), or a home network (Private).\nmacOS: Checks whether the macOS firewall is enabled."
+  local testName="$1"
+  local testDisplayName="$2"
+  local testDescription="$3"
   local riskScore=100
 
   vlRunCommand /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
@@ -184,13 +184,16 @@ vlGetFirewallApprovedApps()
 
 vlFirewallTests()
 {
-  vlCheckIsFirewallEnabled || return $(( $? - 1 ))
-
-  ## TODO: Review and adapt the user-facing text
-  local testName="Firewallo"
+  local testName="FWState"
   local testDisplayName="Firewall status"
-  local testDescription="Comprehensive firewall tests"
+  local testDescription="Windows: This test verifies whether the Windows Defender Firewall is enabled or disabled. It also provides the current connection status of the network profiles. Network profiles allow the system to apply different firewall settings based on the network location, such as a public Wi-Fi network (Public), a corporate network (Domain), or a home network (Private). macOS: performs comprehensive checking of firewall settings. If the firewall is enabled, this test also validates the status of the block-all rule, stealth mode, and a list of approved applications."
   local riskScore=100
+
+  vlCheckIsFirewallEnabled \
+    "$testName" \
+    "$testDisplayName" \
+    "$testDescription" \
+    || return $(( $? - 1 ))
 
   vlCheckIsFirewallBlockallRuleEnabled || return 1
   vlCheckIsFirewallStealthModeEnabled || return 1


### PR DESCRIPTION
As done with the SSH tests, aggregate the Firewall tests into a single test score to match the behavior on Windows.

Sample output:
```
[
  {
    "Name": "Firewallo",
    "DisplayName": "Firewall status",
    "Description": "Comprehensive firewall tests",
    "Score": 5,
    "RiskScore": 100,
    "ResultData": "{
\"FirewallEnabled\":true,
\"BlockAllRuleEnabled\":false,
\"StealthModeEnabled\":false,
\"ApprovedApplications\":[\"/System/Library/CoreServices/ControlCenter.app\",\"/Applications/Docker.app\",\"/Applications/Focusrite Control.app/Contents/Library/LoginItems/FocusriteControlServer.app\",\"/System/Library/CoreServices/RemoteManagement/ARDAgent.app\"]}"
  }
]
```

@martin-kretzschmar Please modify the TODO sections to match the desired wording.

See also the [updated test protocol for this SCI test](https://podio.com/uberagentcom/uberagent-dev/apps/test-protocols/items/582).