### PR TITLE
macOS: Aggregate and extend the automatic OS updates tests

### DIFF
--- a/config-dev/Security inventory/macOS/Updates/Updates.zsh
+++ b/config-dev/Security inventory/macOS/Updates/Updates.zsh
@@ -45,7 +45,7 @@ vlAverageScores()
   printf "$testScore"
 }
 
-vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled()
+vlCheckMacOSUpdatesEnabled()
 {
   local testName="SWUAutomaticUpdateCheckingEnabled"
   local testDisplayName="macOS updates"
@@ -135,7 +135,7 @@ vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled()
   return 0
 }
 
-vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled()
+vlCheckAppStoreUpdatesEnabled()
 {
   local testName="SWUAutomaticUpdateAppStoreCheckingEnabled"
   local testDisplayName="macOS AppStore updates"
@@ -181,9 +181,9 @@ vlCheckForRecommendedUpdates()
 
 vlUpdatesTests()
 {
-  vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled || return 1
+  vlCheckMacOSUpdatesEnabled || return 1
 
-  vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled
+  vlCheckAppStoreUpdatesEnabled
 }
 
 ################################################################################

--- a/config-dev/Security inventory/macOS/Updates/Updates.zsh
+++ b/config-dev/Security inventory/macOS/Updates/Updates.zsh
@@ -2,28 +2,137 @@
 # Security and Compliance Inventory: OS Updates Tests
 #
 
+# Global variables collecting the results for each executed test
+scoresForAllTests=()
+resultDataForAllTests="{}"
+
+
+vlCheckPlistKey()
+{
+  local plistDomain="$1"
+  local plistKey="$2"
+  local plistDefaultOnMissingKey="$3"
+  local resultDataPropertyName="$4"
+  local riskScore="$5"
+
+  vlRunCommand defaults read "$plistDomain" "$plistKey"
+
+  # Attempt to read the plist value, but use the default value (manually from the UI)
+  # if the key domain pair is not found.
+  local plistValue="$plistDefaultOnMissingKey"
+  if (( $vlCommandStatus == 0 )); then
+    plistValue="$vlCommandStdout"
+  fi
+
+  if (( plistValue == 1 )); then
+    scoresForAllTests+=(10)
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+  else
+    scoresForAllTests+=( $( vlGetMinScore "$riskScore" ) )
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+  fi
+}
+
+vlAverageScores()
+{
+  # Use the average of all sub scores as the final score.
+  local sum=0
+  for score in "${scoresForAllTests[@]}"; do
+    sum=$((sum + score))
+  done
+
+  local testScore=$(echo "$sum / ${#scoresForAllTests[@]}" | bc)
+  printf "$testScore"
+}
+
 vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled()
 {
   local testName="SWUAutomaticUpdateCheckingEnabled"
   local testDisplayName="macOS updates"
-  local testDescription="Disabling automatic update checks on macOS can leave the system vulnerable to threats. This test verifys if automatic update checks are enabled."
+  local testDescription="Disabling automatic update checks on macOS can leave the system vulnerable to threats. This test verifys that automatic update checks are enabled."
   local riskScore=100
 
-  local expectedOutput="Automatic checking for updates is turned on"
-  local expectedGrepStatus=0
-  local expectedTestResultDataValue=true
-  local testResultVarName='Enabled'
+  vlRunCommand softwareupdate --schedule
 
-  vlCheckFeatureStateFromCommandOutput \
+  # The softwareupdate always returns zero, even on failure.
+  if [ -n "$vlCommandStderr" ]; then
+    local errorCode=1
+    local errorMessage=$( printf "$vlCommandStderr" | head -n1 )
+    vlReportErrorJson \
+      "$testName" \
+      "$testDisplayName" \
+      "$testDescription" \
+      "$errorCode" \
+      "$errorMessage"
+    return 2
+  fi
+
+  local resultDataPropertyName="AutomaticUpdatesEnabled"
+  printf "$vlCommandStdout" | grep "Automatic checking for updates is turned on" >/dev/null 2>&1
+  case $? in
+    0)
+      scoresForAllTests+=(10)
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "true")
+      ;;
+    1)
+      scoresForAllTests+=(0)
+      resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "${resultDataPropertyName}" "false")
+
+      vlCheckForRecommendedUpdates
+
+      vlCreateResultObject \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        "$( vlAverageScores )" \
+        "$riskScore" \
+        "$resultDataForAllTests"
+
+      return 0
+      ;;
+    *)
+      vlReportErrorJson \
+        "$testName" \
+        "$testDisplayName" \
+        "$testDescription" \
+        "$?" \
+        "Internal error: pattern matching failed."
+      return 2
+      ;;
+  esac
+
+  vlCheckPlistKey \
+    "/Library/Preferences/com.apple.SoftwareUpdate" \
+    "AutomaticDownload" \
+    1 \
+    "AutomaticDownloadEnabled" \
+    80
+
+  vlCheckPlistKey \
+    "/Library/Preferences/com.apple.SoftwareUpdate" \
+    "AutomaticallyInstallMacOSUpdates" \
+    0 \
+    "AutomaticaInstallOSUpdatesEnabled" \
+    80
+
+  vlCheckPlistKey \
+    "/Library/Preferences/com.apple.SoftwareUpdate" \
+    "ConfigDataInstall" \
+    1 \
+    "InstallSecurityResponsesEnabled" \
+    100
+
+  vlCheckForRecommendedUpdates
+
+  vlCreateResultObject \
     "$testName" \
     "$testDisplayName" \
     "$testDescription" \
+    "$( vlAverageScores )" \
     "$riskScore" \
-    "$expectedOutput" \
-    "$expectedGrepStatus" \
-    "$expectedTestResultDataValue" \
-    "$testResultVarName" \
-    softwareupdate --schedule
+    "$resultDataForAllTests"
+
+  return 0
 }
 
 vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled()
@@ -51,40 +160,30 @@ vlCheckForRecommendedUpdates()
   local testDescription="Provides a list of pending recommended macOS software updates."
   local riskScore=90
 
-  local resultData=$(vlAddResultValue "{}" "RecommendedUpdates" '[]')
+  resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "RecommendedUpdates" '[]')
 
+  local availableRecommendedUpdates=0
   ## The softwareupdate doesn't use return codes to indicate sucess or failure.
   softwareupdate -l 2>/dev/null \
     | grep 'Recommended: YES' | cut -d"," -f1 | cut -d":" -f2 | awk '{$1=$1};1' \
     | while IFS= read -r availableUpdate
   do
-    resultData=$(vlAddResultValue "$resultData" "RecommendedUpdates" "[\"$availableUpdate\"]")
+    resultDataForAllTests=$(vlAddResultValue "${resultDataForAllTests}" "RecommendedUpdates" "[\"$availableUpdate\"]")
+    availableRecommendedUpdates=$(( availableRecommendedUpdates + 1 ))
   done
 
-  local testScore=$( vlGetMinScore "$riskScore" )
-  if [ ${#availableRecommendedUpdates[@]} -eq 0 ]; then
-    local testScore=10
+  if (( availableRecommendedUpdates == 0 )); then
+    scoresForAllTests+=(10)
+  else
+    scoresForAllTests+=($( vlGetMinScore "$riskScore" ))
   fi
-
-  vlCreateResultObject "$testName" "$testDisplayName" "$testDescription" "$testScore" "$riskScore" "$resultData"
 }
 
-vlCheckInstallSecurityResponsesAndSystemFilesEnabled()
+vlUpdatesTests()
 {
-  local testName="SWUInstallSecurityResponsesAndSystemFilesEnabled"
-  local testDisplayName="macOS security response updates"
-  local testDescription="Checks whether the automatic installation of security responses and system files is enabled."
-  local riskScore=80
-  local plistDefault=1
+  vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled || return 1
 
-  vlCheckFeatureEnabledFromPlistDomainKey \
-    "$testName" \
-    "$testDisplayName" \
-    "$testDescription" \
-    $riskScore \
-    "/Library/Preferences/com.apple.SoftwareUpdate" \
-    "ConfigDataInstall" \
-    $plistDefault
+  vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled
 }
 
 ################################################################################
@@ -97,10 +196,5 @@ vlUtils="$(cd "$(dirname "$0")/.." && pwd)/Utils.zsh"
 
 # Run the tests
 results=()
-
-results+="$( vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled )"
-results+="$( vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled )"
-results+="$( vlCheckForRecommendedUpdates )"
-results+="$( vlCheckInstallSecurityResponsesAndSystemFilesEnabled )"
-
+results+="$( vlUpdatesTests )"
 vlPrintJsonReport "${results[@]}"

--- a/config-dev/Security inventory/macOS/Updates/Updates.zsh
+++ b/config-dev/Security inventory/macOS/Updates/Updates.zsh
@@ -49,7 +49,7 @@ vlCheckIsAutomaticCheckingForMacOSUpdatesEnabled()
 {
   local testName="SWUAutomaticUpdateCheckingEnabled"
   local testDisplayName="macOS updates"
-  local testDescription="Disabling automatic update checks on macOS can leave the system vulnerable to threats. This test verifys that automatic update checks are enabled."
+  local testDescription="Disabling automatic update checks on macOS can leave the system vulnerable to threats. This test verifies that automatic update checks are enabled."
   local riskScore=100
 
   vlRunCommand softwareupdate --schedule
@@ -139,7 +139,7 @@ vlCheckIsAutomaticCheckingForAppStoreUpdatesEnabled()
 {
   local testName="SWUAutomaticUpdateAppStoreCheckingEnabled"
   local testDisplayName="macOS AppStore updates"
-  local testDescription="Deactivating AppStore updates can result in out-of-date applications, increasing the risk of security breaches. This test verifys if AppStore update checks are enabled."
+  local testDescription="Deactivating AppStore updates can result in out-of-date applications, increasing the risk of security breaches. This test verifies if AppStore update checks are enabled."
   local riskScore=80
   local plistDefault=0
 


### PR DESCRIPTION
Following the SCI test behavior on Windows, group dependent tests into a single test score:

- AutomaticUpdatesEnabled now includes the existing InstallSecurityResponses test into the same score.
- AutomaticDownloadEnabled and AutomaticaInstallOSUpdatesEnabled are new tests added to the AutomaticUpdatesEnabled score to make it more accurate.
- RecommendedUpdates is now a ResultData field in AutomaticUpdatesEnabled while it now also contributes to the score. In particular, when no recommended updates are available, a higher score is achieved.

For more details on the expected behavior, see the [updated test protocol](https://podio.com/uberagentcom/uberagent-dev/apps/test-protocols/items/583).

Sample output:
```
[
  {
    "Name": "SWUAutomaticUpdateCheckingEnabled",
    "DisplayName": "macOS updates",
    "Description": "Disabling automatic update checks on macOS can leave the system vulnerable to threats. This test verifies that automatic update checks are enabled.",
    "Score": 6,
    "RiskScore": 100,
    "ResultData": "{\"AutomaticUpdatesEnabled\":true,\"AutomaticDownloadEnabled\":false,\"AutomaticaInstallOSUpdatesEnabled\":false,\"InstallSecurityResponsesEnabled\":true,\"RecommendedUpdates\":[]}"
  },
  {
    "Name": "SWUAutomaticUpdateAppStoreCheckingEnabled",
    "DisplayName": "macOS AppStore updates",
    "Description": "Deactivating AppStore updates can result in out-of-date applications, increasing the risk of security breaches. This test verifies if AppStore update checks are enabled.",
    "Score": 2,
    "RiskScore": 80,
    "ResultData": "{\"Enabled\":false}"
  }
]
```