### PR TITLE
B801: align test result display with Windows implementation

### DIFF
--- a/config-dev/Security inventory/macOS/LocalUsersAndGroups/LocalUsersAndGroups-User.zsh
+++ b/config-dev/Security inventory/macOS/LocalUsersAndGroups/LocalUsersAndGroups-User.zsh
@@ -41,7 +41,8 @@ vlCheckLocalUserIsAdmin()
     testScore=4
   fi
   
-  resultData=$(vlAddResultValue "{}" "Current user admin" "$isUserAdmin")
+  resultData=$(vlAddResultValue "{}" "IsLocalAdmin" "$isUserAdmin")
+  resultData=$(vlAddResultValue "$resultData" "Username" "$originalUser")  
   
   # Create the result object 
   vlCreateResultObject "$testName" "$testDisplayName" "$testDescription" "$testScore" "$riskScore" "$resultData"


### PR DESCRIPTION
This PR adds the user name to the test result for the LUUIsAdmin test to match the result display of the Windows implementation.