### PR TITLE
Fix/create archive config (PR226)

### DIFF
--- a/.github/workflows/CreateArchive.yml
+++ b/.github/workflows/CreateArchive.yml
@@ -132,6 +132,7 @@ jobs:
 
   publish-archive:
     if: ${{ github.event_name == 'push' }}
+    needs: [create-archive]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
CreateArchive.yml: create dependency on the 'create-archive' step to prevent them from running in parallel (`2ffdd3a`).