### PR TITLE
B983: Minor link update to previous PR.

### DIFF
--- a/config/uberAgent-eventdata-filter.conf
+++ b/config/uberAgent-eventdata-filter.conf
@@ -1,6 +1,6 @@
 ############################################
 #
-# Documentation for EventDataFilter: https://docs.citrix.com/en-us/uberagent/current-release/uxm-features-configuration/event-data-filtering.html
+# Documentation for EventDataFilter: https://docs.citrix.com/en-us/uberagent/current-release/uxm-features-configuration/event-data-filtering/
 #
 ############################################
 


### PR DESCRIPTION
Merged `develop` earlier today too fast. This was fixed in all other PRs right away but didn't land in `develop`.