### PR TITLE
Set config check version to 7.2.

### DIFF
--- a/.github/workflows/Configuration.yml
+++ b/.github/workflows/Configuration.yml
@@ -21,7 +21,7 @@ env:
   uAConfigCheck_EXE_Artifact_Version: "*"
   uAConfigCheck_EXE_Artifact_Package: uaconfigcheck
   uAConfigCheck_DLL_Artifact_Version: "*"
-  uAConfigCheck_DLL_Artifact_ProductVersion: ${{ (github.ref == 'refs/heads/version/7.2' && '7.2.1') || 'develop' }}
+  uAConfigCheck_DLL_Artifact_ProductVersion: "7.2.1"
   uAConfigCheck_DLL_Artifact_Package: uberagent
 
 jobs:


### PR DESCRIPTION
Updating the configuration to check version 7.2.1 in this branch. This ensures that PRs against this branch are validated against version 7.2.1 instead of the 'develop' version.