### PR TITLE
Update timer description for one-shot timers

### DIFF
--- a/config/uberAgent-data-volume-optimized.conf
+++ b/config/uberAgent-data-volume-optimized.conf
@@ -408,8 +408,8 @@ RESTToken =
 #   Required: no
 #
 #   Setting name: Interval
-#   Description: How long to wait before collecting data again. Unit: milliseconds.
-#   Valid values: any positive integer
+#   Description: How long to wait before collecting data again. Setting the interval to zero creates a one-shot timer that triggers after its delay time. Unit: milliseconds.
+#   Valid values: any positive integer or zero
 #   Default: [none]
 #   Required: yes
 #

--- a/config/uberAgent.conf
+++ b/config/uberAgent.conf
@@ -405,8 +405,8 @@ RESTToken =
 #   Required: no
 #
 #   Setting name: Interval
-#   Description: How long to wait before collecting data again. Unit: milliseconds.
-#   Valid values: any positive integer
+#   Description: How long to wait before collecting data again. Setting the interval to zero creates a one-shot timer that triggers after its delay time. Unit: milliseconds.
+#   Valid values: any positive integer or zero
 #   Default: [none]
 #   Required: yes
 #


### PR DESCRIPTION
This pull request update the timer description for field `Interval`. It adds information about how to add a one-shot timer that is executed only once.