### PR TITLE
B676 Configurable logon processes

### DIFF
--- a/config/uberAgent-data-volume-optimized.conf
+++ b/config/uberAgent-data-volume-optimized.conf
@@ -1047,6 +1047,17 @@ AcroRd32.exe = 15000
 
 ############################################
 #
+# The list of processes to ignore in logon monitoring
+#
+############################################
+
+[IgnoreLogonMonitoringProcesses]
+NiAgnt32.exe
+LoginPI.Logon.exe
+LoginPI.Engine.exe
+
+############################################
+#
 # Includes (config files to be processed, too)
 #
 ############################################

--- a/config/uberAgent.conf
+++ b/config/uberAgent.conf
@@ -1044,6 +1044,17 @@ AcroRd32.exe = 15000
 
 ############################################
 #
+# The list of processes to ignore in logon monitoring
+#
+############################################
+
+[IgnoreLogonMonitoringProcesses]
+NiAgnt32.exe
+LoginPI.Logon.exe
+LoginPI.Engine.exe
+
+############################################
+#
 # Includes (config files to be processed, too)
 #
 ############################################


### PR DESCRIPTION
Add the list of ignored logon processes that used to be hard-coded in the agent before B676.