### PR TITLE
1465: Simplify Sigma workflow: remove Poetry, use pip for all Python dependencies

### DIFF
--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -88,13 +88,6 @@ jobs:
         path: pySigma-backend-uberAgent
         ref: ${{ matrix.converter-ref }}
 
-    - name: Checkout sigma-cli
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.VLSVC_PAT }}
-        repository: SigmaHQ/sigma-cli
-        path: sigma-cli
-
     - name: Checkout sigma
       uses: actions/checkout@v4
       with:
@@ -107,22 +100,13 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install Poetry
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: "1.4.2"
-
-    - name: Install
-      working-directory: ./sigma-cli
-      run: poetry install
-
-    - name: Install pySigma-backend-uberAgent from pyPI
-      working-directory: ./sigma-cli
+    - name: Install sigma-cli and dependencies
       env:
         PYPI_HOST: ${{ matrix.pypi-host }}
       run: |
-        poetry source add ua_package_source ${{ matrix.pypi-host }}
-        poetry add --source ua_package_source pySigma-backend-uberAgent
+        python -m pip install --upgrade pip
+        python -m pip install sigma-cli
+        python -m pip install --extra-index-url ${{ matrix.pypi-host }} pySigma-backend-uberAgent
 
     - name: Prepare Build
       run: mkdir build
@@ -134,9 +118,6 @@ jobs:
         CURRENT_BACKEND_VERSION: ${{ matrix.backend-version }}
         COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
       run: |
-        # Activate poetry shell from sigma-cli in this shell
-        . $(cd $GITHUB_WORKSPACE/sigma-cli ; poetry env info --path)/bin/activate
-
         # Copy rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules" $COPY_RULES_ARGS
@@ -145,9 +126,6 @@ jobs:
       if: ${{ matrix.branch == 'develop' }}
       working-directory: build
       run: |
-        # Activate poetry shell from sigma-cli in this shell
-        . $(cd $GITHUB_WORKSPACE/sigma-cli ; poetry env info --path)/bin/activate
-
         # For testing, limited to develop.
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules-threat-hunting" --skip_check_directory
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/copy-rules.py "$GITHUB_WORKSPACE/sigma/rules-emerging-threats" --skip_check_directory
@@ -159,9 +137,6 @@ jobs:
         CURRENT_BACKEND_VERSION: ${{ matrix.backend-version }}
         COPY_RULES_ARGS: ${{ matrix.copy_rules_args }}
       run: |
-        # Activate poetry shell from sigma-cli in this shell
-        . $(cd $GITHUB_WORKSPACE/sigma-cli ; poetry env info --path)/bin/activate
-
         # Convert rules
         chmod +x $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh
         $GITHUB_WORKSPACE/pySigma-backend-uberAgent/convert-rules.sh $(pwd) $CURRENT_PIPELINE_VERSION $CURRENT_BACKEND_VERSION


### PR DESCRIPTION
This pull request updates the `.github/workflows/Sigma.yml` workflow to simplify dependency management and remove the use of Poetry for installing `sigma-cli` and related packages. The workflow now uses pip for all Python package installations, which streamlines setup and improves maintainability.

**Dependency management simplification:**

* Removed all steps related to checking out the `sigma-cli` repository and installing dependencies with Poetry. The workflow now installs `sigma-cli` directly from PyPI using pip. [[1]](diffhunk://#diff-05312878736714b63347e85e5672064c2f4cba4fba793c594ef283bac5ae01f7L91-L97) [[2]](diffhunk://#diff-05312878736714b63347e85e5672064c2f4cba4fba793c594ef283bac5ae01f7L110-R109)
* Consolidated the installation of `pySigma-backend-uberAgent` to use pip with an extra index URL, eliminating the need for Poetry sources and commands.

**Workflow shell environment cleanup:**

* Removed activation of Poetry virtual environments before running scripts, since all dependencies are now installed globally via pip. [[1]](diffhunk://#diff-05312878736714b63347e85e5672064c2f4cba4fba793c594ef283bac5ae01f7L137-L139) [[2]](diffhunk://#diff-05312878736714b63347e85e5672064c2f4cba4fba793c594ef283bac5ae01f7L148-L150) [[3]](diffhunk://#diff-05312878736714b63347e85e5672064c2f4cba4fba793c594ef283bac5ae01f7L162-L164)Decouple sigma-cli; use from pip instead of from source.

**Test**
See the followign workflow run as test reference:

- https://github.com/svnscha/uberAgent-config/actions/runs/17488057871