### PR TITLE
Maintenance: Update version 7.5

### DIFF
--- a/.github/workflows/Configuration.yml
+++ b/.github/workflows/Configuration.yml
@@ -3,12 +3,12 @@ name: Configuration
 on:
   push:
     branches:
-      - develop
+      - "version/7.5"
     paths-ignore:
       - "config-dist/**" # avoid recursion
   pull_request:
     branches:
-      - develop
+      - "version/7.5"
     paths-ignore:
       - "config-dist/**" # avoid recursion
 


### PR DESCRIPTION
This pull request updates the CI workflow configuration to target the `version/7.5` branch instead of `develop`. This ensures that workflow actions such as push and pull request events are only triggered for changes involving the `version/7.5` branch.

* Changed workflow triggers in `.github/workflows/Configuration.yml` to run on `version/7.5` branch for both push and pull request events, replacing the previous `develop` branch configuration.