### PR TITLE
Fix maintained branch workflows on version/7.4

### DIFF
--- a/.github/workflows/Configuration.yml
+++ b/.github/workflows/Configuration.yml
@@ -3,11 +3,17 @@ name: Configuration
 on:
   push:
     branches:
+      - develop
+      - "version/8.0"
+      - "version/7.5"
       - "version/7.4"
     paths-ignore:
       - "config-dist/**" # avoid recursion
   pull_request:
     branches:
+      - develop
+      - "version/8.0"
+      - "version/7.5"
       - "version/7.4"
     paths-ignore:
       - "config-dist/**" # avoid recursion
@@ -20,7 +26,6 @@ env:
 jobs:
   build-archive:
     name: Build
-    # Add "id-token" with the intended permissions.
     permissions:
       id-token: write
       contents: read
@@ -32,14 +37,29 @@ jobs:
           fetch-depth: 0
 
       - name: "Validate uberAgent.conf <> uberAgent-data-volume-optimized.conf"
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          CONFIG_CHANGED="$(git diff --name-only config/uberAgent.conf)"
-          CONFIG_OPTIMIZED_CHANGED="$(git diff --name-only config/uberAgent-data-volume-optimized.conf)"
+          if [ -n "${GITHUB_BASE_REF}" ]; then
+            git fetch origin "${GITHUB_BASE_REF}" --depth=1
+            DIFF_RANGE="origin/${GITHUB_BASE_REF}...HEAD"
+          elif [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            DIFF_RANGE="${BEFORE_SHA}..HEAD"
+          else
+            EMPTY_TREE="$(git hash-object -t tree /dev/null)"
+            DIFF_RANGE="${EMPTY_TREE}..HEAD"
+          fi
+
+          CONFIG_CHANGED="$(git diff --name-only "${DIFF_RANGE}" -- config/uberAgent.conf)"
+          CONFIG_OPTIMIZED_CHANGED="$(git diff --name-only "${DIFF_RANGE}" -- config/uberAgent-data-volume-optimized.conf)"
+
           if ( [ -n "${CONFIG_CHANGED}" ] && [ -z "${CONFIG_OPTIMIZED_CHANGED}" ] ) || ( [ -z "${CONFIG_CHANGED}" ] && [ -n "${CONFIG_OPTIMIZED_CHANGED}" ] )
           then
             echo "Changes must be applied uberAgent.conf and uberAgent-data-volume-optimized.conf, too."
             exit 1
           fi
+
           echo "Changes are in sync."
           exit 0
         continue-on-error: false
@@ -59,7 +79,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Publishing is limited to actual push events.
   push-archive:
     if: ${{ github.event_name == 'push' }}
     name: Push

--- a/.github/workflows/Transpile.yml
+++ b/.github/workflows/Transpile.yml
@@ -2,14 +2,15 @@ name: Transpile SCI Scripts
 
 on:
   push:
-    branches-ignore:
-      - "main"
-      - "version/7.0"
-      - "version/6.2"
+    branches:
+      - develop
+      - "version/8.0"
+      - "version/7.5"
+      - "version/7.4"
 
 jobs:
   transpile:
-    runs-on: ${{ (startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/version/')) && 'windows-latest' || 'ubuntu-latest' }}
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,13 +44,11 @@ jobs:
         run: python config-dev/analyzeLog.py --log_level note --fail_level error
 
       - name: Signing Powershell scripts
-        if: success() && (startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/version/'))
+        if: success()
         shell: powershell
         run: |
           try {
-            # Create buffer from the BASE64 string of the PFX stored in the secret
             $buffer = [System.Convert]::FromBase64String($env:BASE64_PFX)
-            # Create new certificate object from the buffer and the certificate pass
             $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::New($buffer, $env:PFX_PASSWORD)
           }
           catch {
@@ -62,7 +61,6 @@ jobs:
           foreach ($script in $scripts) {
             try {
               Write-Output "Signing script `"$($script.Name)`" with certificate `"$($certificate.Thumbprint)`""
-              # sign script
               $null = Set-AuthenticodeSignature -HashAlgorithm SHA256 -Certificate $certificate -FilePath $script.FullName -TimestampServer "http://timestamp.comodoca.com/rfc3161"
             }
             catch {
@@ -81,8 +79,8 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
 
-      - name: Commit everything - release branch
-        if: success() && (startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/version/'))
+      - name: Commit everything - maintained branch
+        if: success()
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Updated transpiled output

--- a/.github/workflows/Transpile.yml
+++ b/.github/workflows/Transpile.yml
@@ -44,7 +44,7 @@ jobs:
         run: python config-dev/analyzeLog.py --log_level note --fail_level error
 
       - name: Signing Powershell scripts
-        if: success()
+        if: success() && (startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/version/'))
         shell: powershell
         run: |
           try {
@@ -80,7 +80,7 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
 
       - name: Commit everything - maintained branch
-        if: success()
+        if: success() && (startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/version/'))
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Updated transpiled output

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # uberAgent Configuration
 
-This repository is the home for the [uberAgent](https://uberagent.com/) configuration. This repository contains UXM configuration settings (timers, metrics, etc.) as well as ESA Threat Detection rules and Security & Compliance Inventory tests.
+This repository is the home for the [uberAgent](https://www.citrix.com/platform/uberagent.html) configuration. This repository contains UXM configuration settings (timers, metrics, etc.) as well as ESA Threat Detection rules and Security & Compliance Inventory tests.
 
 ## Getting Started
 
 1. Select the Git branch that matches your installed uberAgent version.
 2. Clone this repository to your machine.
-3. Update the files in your [uberAgent configuration](https://uberagent.com/docs/uberagent/latest/planning/configuration-options/) 
+3. Update the files in your [uberAgent configuration](https://docs.citrix.com/en-us/uberagent/current-release/planning/configuration-options)
    - Choose either the files from the `config` or `config-dist` folders of this repository, depending on your uberAgent version (see [uberAgent Versions & Git Branches](#uberagent-versions--git-branches)).
    - The process can be automated. See [Automating uberAgent Configuration Updates](#automating-uberagent-configuration-updates).
 
@@ -17,17 +17,18 @@ This repository is the home for the [uberAgent](https://uberagent.com/) configur
 This repository is organized in such a way that uberAgent releases are represented by Git branches. Each Git branch contains rules that are compatible with the matching uberAgent release.
 
 | uberAgent version | Git branch |
-| ------- | --------------------- |
+| --- | --- |
 | `development (beta)` | [develop](../../tree/develop) |
-| `7.0.x` | [version/7.0](../../tree/version/7.0) |
-| `6.2.x` | [version/6.2](../../tree/version/6.2) |
+| `8.x` | [version/8.0](../../tree/version/8.0) |
+| `7.5.x` | [version/7.5](../../tree/version/7.5) |
+| `7.4.x` | [version/7.4](../../tree/version/7.4) |
 
 ### Folder Structure
 
-| Folder        | Description                                                  |
-| ------------- | ------------------------------------------------------------ |
-| `config`      | Compiled configuration as individual source files. Use the contents of this folder for your **deployment with any uberAgent version**. |
-| `config-dev`  | Contains files that cannot be used without further processing, such as transpilation. Do not use the contents of this folder on your endpoints unless you know what you're doing. |
+| Folder | Description |
+| --- | --- |
+| `config` | Compiled configuration as individual source files. Use the contents of this folder for your **deployment with any uberAgent version**. |
+| `config-dev` | Contains files that cannot be used without further processing, such as transpilation. Do not use the contents of this folder on your endpoints unless you know what you're doing. |
 | `config-dist` | Compiled configuration as configuration archive (`*.uAConfig`). Use the contents of this folder for your **deployment with uberAgent 7.1+**. |
 
 ## Automating uberAgent Configuration Updates
@@ -38,4 +39,4 @@ To make your life easier, we provide a PowerShell script that automates the conf
 
 ## Help and Support
 
-Please see the [uberAgent documentation portal](https://uberagent.com/docs/) for docs, help and support options.
+Please see the [uberAgent documentation portal](https://docs.citrix.com/en-us/uberagent/current-release/) for docs, help and support options.


### PR DESCRIPTION
## Summary
- make Configuration workflow diffing work correctly on the version/7.4 branch
- limit Transpile workflow triggers to maintained branches only
- refresh the README branch matrix for the maintained support scope