### PR TITLE
Limit Sigma workflow to maintained branches

### DIFF
--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -10,27 +10,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - branch: version/7.1
-            pipeline_version: "uberagent-7.1.0"
-            backend-version: "7.1.0"
-            copy_rules_args: ""
-            pypi-host: "https://pypi.org/simple"
-            converter-ref: "main"
-
-          - branch: version/7.2
-            pipeline_version: "uberagent-7.2.0"
-            backend-version: "7.2.0"
-            copy_rules_args: ""
-            pypi-host: "https://pypi.org/simple"
-            converter-ref: "main"
-
-          - branch: version/7.3
-            pipeline_version: "uberagent-7.3.0"
-            backend-version: "7.3.0"
-            copy_rules_args: ""
-            pypi-host: "https://pypi.org/simple"
-            converter-ref: "main"
-
           - branch: version/7.4
             pipeline_version: "uberagent-7.4.0"
             backend-version: "7.4.0"
@@ -41,6 +20,13 @@ jobs:
           - branch: version/7.5
             pipeline_version: "uberagent-7.5.0"
             backend-version: "7.5.0"
+            copy_rules_args: ""
+            pypi-host: "https://pypi.org/simple"
+            converter-ref: "main"
+
+          - branch: version/8.0
+            pipeline_version: "uberagent-8.0.0"
+            backend-version: "8.0.0"
             copy_rules_args: ""
             pypi-host: "https://pypi.org/simple"
             converter-ref: "main"


### PR DESCRIPTION
## Summary
- remove EOM branches `version/7.1`, `version/7.2`, and `version/7.3` from the daily Sigma workflow on `main`
- keep the scheduled Sigma workflow aligned with the actively maintained uberAgent branches
- keep the change focused on `.github/workflows/Sigma.yml` only

## Why
- `version/8.0` is now already present on `main` via #332
- this PR now carries the remaining cleanup needed to bring the daily Sigma matrix in line with the maintained support scope