### PR TITLE
Version: Enable Sigma generation for 8.1

### DIFF
--- a/.github/workflows/Sigma.yml
+++ b/.github/workflows/Sigma.yml
@@ -31,6 +31,13 @@ jobs:
             pypi-host: "https://pypi.org/simple"
             converter-ref: "main"
 
+          - branch: version/8.1
+            pipeline_version: "uberagent-8.0.0" # No relevant changes for the converter, so we can use the same version as for 8.0.
+            backend-version: "8.0.0"            # No relevant changes for the converter, so we can use the same version as for 8.0.
+            copy_rules_args: ""
+            pypi-host: "https://pypi.org/simple"
+            converter-ref: "main"
+
           - branch: develop
             pipeline_version: "uberagent-develop"
             backend-version: "develop"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This repository is organized in such a way that uberAgent releases are represent
 | uberAgent version    | Git branch                            |
 | -------------------- | ------------------------------------- |
 | `development (beta)` | [develop](../../tree/develop)         |
-| `8.x`                | [version/8.0](../../tree/version/8.0) |
+| `8.x`                | [version/8.1](../../tree/version/8.1) |
+| `8.0`                | [version/8.0](../../tree/version/8.0) |
 | `7.5.x`              | [version/7.5](../../tree/version/7.5) |
 | `7.4.x`              | [version/7.4](../../tree/version/7.4) |
 


### PR DESCRIPTION
This pull request updates the repository to add support for the new `version/8.1` branch of uberAgent, ensuring both documentation and CI workflows reflect this addition.

Repository organization and documentation:

* Updated the branch table in `README.md` to include the new `version/8.1` branch for the `8.x` line and clarified the mapping for `8.0` and `8.x` versions.

Continuous Integration (CI) workflow:

* Added a new job entry for the `version/8.1` branch in the `.github/workflows/Sigma.yml` workflow, aligning its pipeline and backend versions with `8.0.0` since there are no relevant converter changes.