### PR TITLE
Fix macOS SCI OsConfiguration failing on macOS 27 (Golden Gate)

### DIFF
--- a/config-dev/Security inventory/macOS/OsConfiguration/OsConfiguration.zsh
+++ b/config-dev/Security inventory/macOS/OsConfiguration/OsConfiguration.zsh
@@ -139,7 +139,7 @@ vlCheckTmEnc()
          "$vlCommandStderr"
       return
    else
-      if echo $vlCommandStdout | grep -q "Mount Point"; then
+      if echo -E "$vlCommandStdout" | grep -q "Mount Point"; then
          local backupMountPoint=$(tmutil destinationinfo | awk -F': ' '/Mount Point/{print substr($0, index($0, $2))}')
          vlRunCommand diskutil list $backupMountPoint
          if (( $vlCommandStatus != 0 )); then
@@ -257,8 +257,8 @@ vlCheckMediaSharing()
             resultObj=$(vlAddResultValue "{}" "User" $user)
             if [[ $vlCommandStatus == 0 ]]; then
                # Parse the output to get the status of home and public sharing preferences.
-               local homeSharing=$(echo $vlCommandStdout | grep -o '"home-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
-               local publicSharing=$(echo $vlCommandStdout | grep -o '"public-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
+               local homeSharing=$(echo -E "$vlCommandStdout" | grep -o '"home-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
+               local publicSharing=$(echo -E "$vlCommandStdout" | grep -o '"public-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
                   # Check if both homeSharing and publicSharing are disabled, else consider media sharing as enabled.
                   if [[ (-z "$homeSharing" || "$homeSharing" == "0") && (-z "$publicSharing" || "$publicSharing" == "0") ]]; then
                      result="false"

--- a/config/Security inventory/macOS/OsConfiguration/OsConfiguration.zsh
+++ b/config/Security inventory/macOS/OsConfiguration/OsConfiguration.zsh
@@ -139,7 +139,7 @@ vlCheckTmEnc()
          "$vlCommandStderr"
       return
    else
-      if echo $vlCommandStdout | grep -q "Mount Point"; then
+      if echo -E "$vlCommandStdout" | grep -q "Mount Point"; then
          local backupMountPoint=$(tmutil destinationinfo | awk -F': ' '/Mount Point/{print substr($0, index($0, $2))}')
          vlRunCommand diskutil list $backupMountPoint
          if (( $vlCommandStatus != 0 )); then
@@ -257,8 +257,8 @@ vlCheckMediaSharing()
             resultObj=$(vlAddResultValue "{}" "User" $user)
             if [[ $vlCommandStatus == 0 ]]; then
                # Parse the output to get the status of home and public sharing preferences.
-               local homeSharing=$(echo $vlCommandStdout | grep -o '"home-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
-               local publicSharing=$(echo $vlCommandStdout | grep -o '"public-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
+               local homeSharing=$(echo -E "$vlCommandStdout" | grep -o '"home-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
+               local publicSharing=$(echo -E "$vlCommandStdout" | grep -o '"public-sharing-enabled" = [0-1];' | awk -F'= ' '{print $2}' | sed 's/;//')
                   # Check if both homeSharing and publicSharing are disabled, else consider media sharing as enabled.
                   if [[ (-z "$homeSharing" || "$homeSharing" == "0") && (-z "$publicSharing" || "$publicSharing" == "0") ]]; then
                      result="false"


### PR DESCRIPTION
The zsh echo builtin interprets backslash escapes. On macOS 27 (Golden Gate), 'defaults read com.apple.amp.mediasharingd' returns a shared-library-name containing a Unicode escape (e.g. 'admin\U2019s Library'). The uberAgent daemon runs SCI scripts as root with no locale (C / single-byte), so echo expanding \U2019 raised 'zsh: character not in range' on stderr, which made the agent discard the entire OsConfiguration script output. Use 'echo -E' to disable escape interpretation and quote the variable in the MediaSharing (home/public-sharing) and TmEnc (Mount Point) checks.